### PR TITLE
Prettify index

### DIFF
--- a/.circle/index.py
+++ b/.circle/index.py
@@ -17,7 +17,7 @@ def build_index(path):
         )
         packs[pack_meta['name']] = pack_meta
     with open('%s/index.json' % path, 'w') as outfile:
-        json.dump(packs, outfile)
+        json.dump(packs, outfile, indent=4)
 
 if __name__ == '__main__':
     path = sys.argv[1]


### PR DESCRIPTION
Pretty-print the index JSON. Will increase the filesize a bit, but the index will be more human-readable, and the diff will get better, too.