### PR TITLE
Various improvements, index format change

### DIFF
--- a/.circle/deployment
+++ b/.circle/deployment
@@ -11,7 +11,7 @@ git clone https://${MACHINE_USER}:${MACHINE_PASSWORD}@github.com/StackStorm-Exch
 cp pack.yaml ~/index/v1/packs/"${PACK_NAME}".yaml
 
 # Rebuild the index JSON
-~/virtualenv/bin/python ~/ci/.circle/index.py --glob "~/index/v1/packs/*.yaml" --output "~/index/v1/packs/"
+~/virtualenv/bin/python ~/ci/.circle/index.py --glob "~/index/v1/packs/*.yaml" --output "~/index/v1/"
 
 # Check if an icon has been added or changed
 ICON_TARGET="${HOME}/index/v1/icons/${PACK_NAME}.png"

--- a/.circle/deployment
+++ b/.circle/deployment
@@ -11,7 +11,7 @@ git clone https://${MACHINE_USER}:${MACHINE_PASSWORD}@github.com/StackStorm-Exch
 cp pack.yaml ~/index/v1/packs/"${PACK_NAME}".yaml
 
 # Rebuild the index JSON
-~/virtualenv/bin/python ~/ci/.circle/index.py ~/index/v1/
+~/virtualenv/bin/python ~/ci/.circle/index.py --glob "~/index/v1/packs/*.yaml" --output "~/index/v1/packs/"
 
 # Check if an icon has been added or changed
 ICON_TARGET="${HOME}/index/v1/icons/${PACK_NAME}.png"

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -30,6 +30,8 @@ def build_index(path_glob, output_path):
         with open(filename, 'r') as pack:
             pack_meta = yaml.load(pack)
 
+        print('Processing pack: %s (%s)' % (pack_meta['name'], filename))
+
         pack_meta['repo_url'] = 'https://github.com/%s/%s-%s' % (
             EXCHANGE_NAME, EXCHANGE_PREFIX, pack_meta['name']
         )

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -26,6 +26,8 @@ def build_index(path_glob, output_path):
 
     path_glob = os.path.expanduser(path_glob)
     generator = sorted(glob(path_glob))
+
+    counter = 0
     for filename in generator:
         with open(filename, 'r') as pack:
             pack_meta = yaml.load(pack)
@@ -38,6 +40,7 @@ def build_index(path_glob, output_path):
         )
         result['packs'][pack_meta['name']] = pack_meta
         data_hash.update(str(pack_meta))
+        counter += 1
 
     result['metadata']['generated_ts'] = int(time.time())
     result['metadata']['hash'] = data_hash.hexdigest()
@@ -47,7 +50,9 @@ def build_index(path_glob, output_path):
         json.dump(result, outfile, indent=4, sort_keys=True,
                   separators=(',', ': '))
 
-    print('Index data written to "%s"' % (output_path))
+    print('')
+    print('Processed %s packs.' % (counter))
+    print('Index data written to "%s".' % (output_path))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Generate StackStorm exchange index.json')

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -31,9 +31,10 @@ def build_index(path_glob, output_path):
             pack_meta = yaml.load(pack)
 
         print('Processing pack: %s (%s)' % (pack_meta['name'], filename))
+        sanitized_pack_name = pack_meta['name'].replace(' ', '-').lower()
 
         pack_meta['repo_url'] = 'https://github.com/%s/%s-%s' % (
-            EXCHANGE_NAME, EXCHANGE_PREFIX, pack_meta['name']
+            EXCHANGE_NAME, EXCHANGE_PREFIX, sanitized_pack_name
         )
         result['packs'][pack_meta['name']] = pack_meta
         data_hash.update(str(pack_meta))

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -2,22 +2,27 @@ import json
 import yaml
 import sys
 from glob import glob
+from collections import OrderedDict
 
 EXCHANGE_NAME = "StackStorm-Exchange"
 EXCHANGE_PREFIX = "stackstorm"
 
 
 def build_index(path):
-    packs = {}
-    for filename in glob('%s/packs/*.yaml' % path):
+    packs = OrderedDict()
+
+    generator = sorted(glob('%s/packs/*.yaml' % path))
+    for filename in generator:
         with open(filename, 'r') as pack:
             pack_meta = yaml.load(pack)
+
         pack_meta['repo_url'] = 'https://github.com/%s/%s-%s' % (
             EXCHANGE_NAME, EXCHANGE_PREFIX, pack_meta['name']
         )
         packs[pack_meta['name']] = pack_meta
+
     with open('%s/index.json' % path, 'w') as outfile:
-        json.dump(packs, outfile, indent=4)
+        json.dump(packs, outfile, indent=4, sort_keys=True)
 
 if __name__ == '__main__':
     path = sys.argv[1]

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -44,7 +44,8 @@ def build_index(path_glob, output_path):
 
     output_path = os.path.expanduser(os.path.join(output_path, 'index.json'))
     with open(output_path, 'w') as outfile:
-        json.dump(result, outfile, indent=4, sort_keys=True)
+        json.dump(result, outfile, indent=4, sort_keys=True,
+                  separators=(',', ': '))
 
     print('Index data written to "%s"' % (output_path))
 


### PR DESCRIPTION
This pull request includes some improvements in the index generation code:

1. It always processes files on the disk in the same order and also sorts the resulting JSON data which is written to the file. This ensures that if we provide the same input data, the end result file (final `index.json`) will be the same and won't change.

2. Changes the file format a bit so the packs are stored under the "packs" key and introduces new top-level "metadata" key which includes various index level metadata. Right now it includes the timestamp when the file has been generated and a hash of all the content. Hash won't change if the input data is the same so people who mirror the index can use this attribute to detect changes.

I know this change breaks the current format, but I think it's more future proof and it's better to give us more flexibility by not storing packs as top-level. I know this will also require changes in st2 and index web.