### PR TITLE
Create version tags

### DIFF
--- a/.circle/deployment
+++ b/.circle/deployment
@@ -23,7 +23,7 @@ then
   echo "Icon uploaded."
 fi
 
-# Commit
+# Commit the index changes
 git -C ~/index add .
 git -C ~/index status
 
@@ -44,4 +44,24 @@ then
 
 else
   echo "No changes to pack metadata, skipping the index update."
+fi
+
+# Create version tags
+PUSH_TAGS=""
+METADATA_CHANGES=$(git rev-list --all --no-abbrev -- pack.yaml)
+cat $METADATA_CHANGES | while read COMMIT
+do
+  git checkout ${COMMIT} pack.yaml > /dev/null
+  VERSION=$(python ../ci/.circle/semver.py pack.yaml 2>/dev/null || true)
+  if [[ ${VERSION} ]] && [[ -z $(git rev-parse -q --verify "refs/tags/v${VERSION}") ]]
+  then
+    echo "Creating tag ${VERSION} for commit ${COMMIT}"
+    git tag -a v${VERSION} -m "$(git show -s --format=%B $COMMIT)" ${COMMIT}
+    PUSH_TAGS="1"
+  fi
+  VERSION=""
+done
+if [[ ${PUSH_TAGS} ]]
+then
+  git push --tags origin 2>/dev/null
 fi

--- a/.circle/semver.py
+++ b/.circle/semver.py
@@ -1,0 +1,39 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import re
+
+import validate
+
+SEMVER_REGEX = "^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?$"
+SINGLE_VERSION_REGEX = "^\d+$"
+DOUBLE_VERSION_REGEX = "^\d+\.\d+$"
+
+
+def get_semver_string(version):
+    if re.match(SINGLE_VERSION_REGEX, str(version)):
+        return "%s.0.0" % version
+    elif re.match(DOUBLE_VERSION_REGEX, str(version)):
+        return "%s.0" % version
+    elif re.match(SEMVER_REGEX, version):
+        return version
+    else:
+        raise ValueError("Cannot convert %s to semver." % version)
+
+if __name__ == '__main__':
+
+    pack = validate.load_yaml_file(sys.argv[1])
+    print get_semver_string(pack['version'])


### PR DESCRIPTION
This PR makes CI create version tags for the commits where `version` in `pack.yaml` has been changed.

There's also a script that converts versions like `1` or `0.1` (the latter is common in st2contrib) to valid semver when creating tags. It won't be necessary in the future, since we already have semver validation for `pack.yaml`, but useful for contrib, since we're preserving history and adding tags retroactively.