### PR TITLE
Chmod circle.yml to 755

### DIFF
--- a/utils/exchange-bootstrap.sh
+++ b/utils/exchange-bootstrap.sh
@@ -71,6 +71,7 @@ fi
 
 # Git: push circle.yml
 curl -sS --fail "https://raw.githubusercontent.com/StackStorm-Exchange/ci/master/.circle/circle.yml.sample" > circle.yml
+chmod 755 circle.yml
 git add circle.yml
 git commit -m 'Bootstrap a StackStorm Exchange pack repository.'
 git push origin master


### PR DESCRIPTION
755 is applied to all pack files on checkout, so we should do it here as well, otherwise git will ask users to commit circle.yml with changed permissions, which is sorta annoying.