### PR TITLE
Store pack content count in index

### DIFF
--- a/.circle/deployment
+++ b/.circle/deployment
@@ -8,11 +8,14 @@ git clone https://${MACHINE_USER}:${MACHINE_PASSWORD}@github.com/StackStorm-Exch
 
 echo "Processing pack ${PACK_NAME}"
 
+# Count content and store it in the index version of pack.yaml
+~/virtualenv/bin/python ~/ci/utils/pack_content.py
 # Move the pack.yaml file to the index
 cp pack.yaml ~/index/v1/packs/"${PACK_NAME}".yaml
+git checkout pack.yaml
 
 # Rebuild the index JSON
-if [[ $(git status -s) ]]
+if [[ $(git -C ~/index status -s) ]]
 then
   ~/virtualenv/bin/python ~/ci/.circle/index.py --glob "~/index/v1/packs/*.yaml" --output "~/index/v1/"
 else

--- a/utils/pack_content.py
+++ b/utils/pack_content.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# A helper script to count content in a pack.
+#
+import os
+import glob
+import yaml
+
+RESOURCE_LOCATOR = {
+  'sensors': {
+    'path': ['sensors/*.yaml', 'sensors/*.yml'],
+    'validate': ['class_name']
+  },
+  'actions': {
+    'path': ['actions/*.yaml', 'actions/*.yml'],
+    'validate': ['name']
+  },
+  'rules': {
+    'path': ['rules/*.yaml', 'rules/*.yml'],
+    'validate': ['name']
+  },
+  'runners': {
+    'path': ['runners/*/runner.yaml', 'runners/*/runner.yml'],
+    'validate': ['name']
+  },
+  'triggers': {
+    'path': ['triggers/*.yaml', 'triggers/*.yml'],
+    'validate': ['name']
+  },
+  'aliases': {
+    'path': ['aliases/*.yaml', 'aliases/*.yml'],
+    'validate': ['name']
+  },
+  'policies': {
+    'path': ['policies/*.yaml', 'policies/*.yml'],
+    'validate': ['name']
+  }
+}
+
+
+def get_pack_resources(pack_dir):
+
+    resources = {}
+
+    for resource, locator in RESOURCE_LOCATOR.iteritems():
+
+        resources[resource] = []
+        matching_files = []
+
+        for path in locator['path']:
+            matching_files += glob.glob(os.path.join(pack_dir, path))
+
+        for file in matching_files:
+            with open(file, 'r') as fp:
+                metadata = fp.read()
+            metadata = yaml.safe_load(metadata)
+            valid = True
+            for validator in locator['validate']:
+                if validator not in metadata:
+                    valid = False
+            if valid:
+                resources[resource].append(metadata)
+
+    # Inaccurate, but for now we'll only need true/false.
+    resources['tests'] = glob.glob(os.path.join(pack_dir, 'tests/*.py'))
+
+    return resources
+
+
+def return_resource_count(resources):
+    return {k: {'count': len(v)} for k, v in resources.iteritems()}
+
+
+if __name__ == '__main__':
+    with open('pack.yaml', 'r+') as file:
+        meta = yaml.load(file.read())
+        content = get_pack_resources('.')
+        meta['content'] = return_resource_count(content)
+        file.seek(0)
+        file.write(yaml.dump(meta))
+        file.truncate()


### PR DESCRIPTION
Scan for pack content and store the count in the index. Full content metadata is not stored, empty content types are excluded.