### PR TITLE
Add script which sets pack repo description to match description from pack.yaml

### DIFF
--- a/tools/set_repo_description.sh
+++ b/tools/set_repo_description.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Script which sets pack Github repo description so it matches "description"
+#
+# Requires: jq
+#
+# attribute from pack.yaml metadata file.
+# * USERNAME: a GitHub user to run the script under (Exchange bot).
+# * PASSWORD: password for the user (not a token).
+# * REPO_NAMES: If specified only set description for specified repo(s)
+#               otherwise set it for all the repos.
+
+set -e
+
+# Include script with common functionality
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/common.sh"
+
+if [ ! -z "${REPO_NAMES}" ]; then
+  OIFS=$IFS;
+  IFS=" "
+  REPO_NAMES=($REPO_NAMES)
+  IFS=$OIFS;
+else
+  get_all_exchange_repo_names "${EXCHANGE_ORG}" "${EXCHANGE_PREFIX}"
+fi
+
+for REPO_NAME in ${REPO_NAMES[@]}; do
+    echo "Setting description for repo: ${REPO_NAME}"
+
+    # Retrieve description from pack.yaml
+    PACK_YAML_URL="https://raw.githubusercontent.com/StackStorm-Exchange/${REPO_NAME}/master/pack.yaml"
+    PACK_DESCRIPTION=$(curl -sS --fail -X GET "${PACK_YAML_URL}" | python -c 'import yaml,sys; c=yaml.safe_load(sys.stdin);print c["description"]')
+
+    if [ -z "${PACK_DESCRIPTION}" ]; then
+        echo "Description not available for pack ${REPO_NAME}, skipping..."
+    else
+        curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X PATCH --header "Content-Type: application/json" \
+        -d '{"name": "'"${REPO_NAME}"'", "description": "'"${PACK_DESCRIPTION}"'", "homepage": "https://exchange.stackstorm.org/"}' \
+        "https://api.github.com/repos/${EXCHANGE_ORG}/${REPO_NAME}"
+
+        sleep ${SLEEP_DELAY}
+    fi
+done

--- a/utils/exchange-bootstrap.sh
+++ b/utils/exchange-bootstrap.sh
@@ -102,6 +102,14 @@ curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X POST --header "Content-Type: app
 	-d '{"name": "web", "active": true, "config": {"url": "'"${SLACK_WEBHOOK_URL}"'", "content_type": "application/json"}, "events": ["commit_comment", "issue_comment", "issues", "pull_request", "pull_request_review", "pull_request_review_comment"]}' \
 	"https://api.github.com/repos/${EXCHANGE_ORG}/${REPO_NAME}/hooks"
 
+# Github: Configure repo description to match "description" attribute in pack.yaml
+PACK_YAML_URL="https://raw.githubusercontent.com/StackStorm-Exchange/${REPO_NAME}/master/pack.yaml"
+PACK_DESCRIPTION=$(curl -sS --fail -X GET "${PACK_YAML_URL}" | python -c 'import yaml,sys; c=yaml.safe_load(sys.stdin);print c["description"]')
+
+curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X PATCH --header "Content-Type: application/json" \
+-d '{"name": "'"${REPO_NAME}"'", "description": "'"${PACK_DESCRIPTION}"'", "homepage": "https://exchange.stackstorm.org/"}' \
+"https://api.github.com/repos/${EXCHANGE_ORG}/${REPO_NAME}"
+
 # CircleCI: follow the project
 curl -sS --fail -X POST "https://circleci.com/api/v1.1/project/github/${EXCHANGE_ORG}/${REPO_NAME}/follow?circle-token=${CIRCLECI_TOKEN}"
 


### PR DESCRIPTION
The title says it all.

In addition to setting Github repo description, it also sets website to https://exchange.stackstorm.org/.

Having description set will make pack discovery through search engines easier.

On a related note - I also wanted to set topics for each repo to match `keywords`, but it looks like there is no API available yet for new Github topics functionality.

Resolves #35.