### PR TITLE
removed extraneous pip cache dir

### DIFF
--- a/.circle/circle.yml.sample
+++ b/.circle/circle.yml.sample
@@ -9,7 +9,6 @@ checkout:
 dependencies:
   cache_directories:
     - ~/.cache/pip
-    - ~/.pip-cache
     - ~/.apt-cache
   override:
     - ~/ci/.circle/dependencies


### PR DESCRIPTION
Removed extra pip cache dir that causes these errors on CircleCI:

```circle.yml specified cache directory: /home/ubuntu/.pip-cache but it does not exist```

Will also need to be propagated to all exchange repos