### PR TITLE
Add a check which verifies pack contains config.schema.yaml and not config.yaml

### DIFF
--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -72,6 +72,10 @@ packs-tests: requirements .clone_st2_repo .packs-tests
 	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_YAML}" ]; then echo "No files have changed, skipping run..."; fi; for file in $(CHANGED_YAML); do if [ -n "$$file" ]; then st2-check-validate-yaml-file $$file || exit 1 ; fi; done
 	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_JSON}" ]; then echo "No files have changed, skipping run..."; fi; for file in $(CHANGED_JSON); do if [ -n "$$file" ]; then st2-check-validate-json-file $$file || exit 1 ; fi; done
 	@echo
+	@echo "==================== config schema check ===================="
+	@echo
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_FILES}" ]; then echo "No files have changed, skipping run..."; else $(CI_DIR)/.circle/validate-config-schema-exists.sh /tmp/packs/$(PACK_NAME) || exit 1; fi;
+	@echo
 	@echo "==================== example config check ===================="
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_FILES}" ]; then echo "No files have changed, skipping run..."; else st2-check-validate-pack-example-config /tmp/packs/$(PACK_NAME) || exit 1; fi;

--- a/.circle/validate-config-schema-exists.sh
+++ b/.circle/validate-config-schema-exists.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PACK_PATH=$1
+
+if [ ! "${PACK_PATH}" ]; then
+    echo "Usage: $0 <pack path>"
+    exit 1
+fi
+
+if [ ! -d "${PACK_PATH}" ]; then
+    echo "Pack directory ${PACK_PATH} doesn't exist"
+    exit 1
+fi
+
+if [ ! -f "${PACK_PATH}/config.schema.yaml" ]; then
+    echo "Pack ${PACK_PATH} is missing config.schema.yaml file"
+    exit 2
+fi
+
+if [ -f "${PACK_PATH}/config.yaml" ]; then
+    echo "Pack ${PACK_PATH} contains config.yaml file which has been deprecated and replaced with config.schema.yaml"
+    exit 2
+fi
+
+exit 0


### PR DESCRIPTION
This pull request adds a CI check for each pack which verifies pack contains `config.schema.yaml` file and no `config.yaml` file.

Note: This should only be merged once we update all the existing packs and make sure they all have `config.schema.yaml`.