### PR TITLE
Be more specific about which lib directory we ignore

### DIFF
--- a/files/.gitignore.sample
+++ b/files/.gitignore.sample
@@ -15,7 +15,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+./lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
We were ignoring any lib directory, but many packs include `./actions/lib` and sometimes `./sensors/lib`. So making the rule more specific to only ignore top-level `./lib` dirs.