### PR TITLE
Enabling test coverage and timing output for pack tests

### DIFF
--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -95,7 +95,7 @@ packs-tests: requirements .clone_st2_repo .packs-tests
 	@echo
 	@echo "==================== packs-tests ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_FILES}" ]; then echo "No files have changed, skipping run..."; else ($(ST2_REPO_PATH)/st2common/bin/st2-run-pack-tests -x -p $(ROOT_DIR) || exit 1); fi;
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_FILES}" ]; then echo "No files have changed, skipping run..."; else ($(ST2_REPO_PATH)/st2common/bin/st2-run-pack-tests -c -t -x -p $(ROOT_DIR) || exit 1); fi;
 
 .PHONY: .packs-missing-tests
 .packs-missing-tests:


### PR DESCRIPTION
I thought it would be a good idea to print out test coverage and timings for unittests in packs similar to what's done in st2 core.

This change depends on st2 PR: https://github.com/StackStorm/st2/pull/3508

And also has supporting documentation here: https://github.com/StackStorm/st2docs/pull/535