### PR TITLE
Flake8 Config path

### DIFF
--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -55,7 +55,7 @@ packs-tests: requirements .clone_st2_repo .packs-tests
 	@echo
 	@echo "==================== flake8 ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_PY}" ]; then echo "No files have changed, skipping run..."; fi; for file in ${CHANGED_PY}; do if [ -n "$$file" ]; then flake8 --config $(CI_DIR)/lint-configs/python/.flake8 $$file || exit 1; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_PY}" ]; then echo "No files have changed, skipping run..."; fi; for file in ${CHANGED_PY}; do if [ -n "$$file" ]; then flake8 --config=$(CI_DIR)/lint-configs/python/.flake8 $$file || exit 1; fi; done
 
 .PHONY: .pylint
 .pylint:


### PR DESCRIPTION
We should use `--config=<config>` not `--config <config>`, according to the flake8 help.