### PR TITLE
handle missing pack.yaml

### DIFF
--- a/.circle/deployment
+++ b/.circle/deployment
@@ -73,7 +73,7 @@ else
 fi
 
 # Create version tags
-METADATA_CHANGES=$(git rev-list --all --no-abbrev -- pack.yaml)
+METADATA_CHANGES=$(git rev-list --all --no-abbrev --remove-empty -- pack.yaml)
 for COMMIT in $(echo $METADATA_CHANGES)
 do
   git checkout ${COMMIT} pack.yaml > /dev/null


### PR DESCRIPTION
In some packs there is no `pack.yaml` in older git history. 

This causes problems in the deployment script when it attempts to pull out all `pack.yaml` versions, and the deployment fails.

This change should handle that situation gracefully.