### PR TITLE
Use git protocol to clone ci repo in .circle/circle.yml.sample

### DIFF
--- a/.circle/circle.yml.sample
+++ b/.circle/circle.yml.sample
@@ -19,7 +19,7 @@ jobs:
       - run:
           name: Download dependencies
           command: |
-            git clone -b master git@github.com:stackstorm-exchange/ci.git ~/ci
+            git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
             ~/ci/.circle/dependencies
       - run:
           name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# JetBrains IDE
+.idea
+
+# Editor saves
+*~


### PR DESCRIPTION
This fixes using CircleCI local builds for StackStrom-Exchange packs, as during local builds the container does not have access to the SSH key from CircleCI and thus can't clone via SSH. Given that the repo is public it can instead be cloned via `git://` which does not prompt to accept a public key or require the SSH key.

- Change git clone to git protocol from ssh (Fixes: #56)
- Add a `.gitignore` file to exclude JetBrains IDE dir and emacs saves.
