### PR TITLE
Fix Metrics Registration

### DIFF
--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -128,8 +128,8 @@ packs-tests: requirements .clone_st2_repo .packs-tests
 	@echo "================== register metrics drivers ======================"
 	@echo ""
 
-        # Install st2common to register metrics drivers
-        (. $(VIRTUALENV_DIR)/bin/activate; cd $(ST2_REPO_PATH)/st2common; python setup.py develop)
+	# Install st2common to register metrics drivers
+	(. $(VIRTUALENV_DIR)/bin/activate; cd $(ST2_REPO_PATH)/st2common; python setup.py develop)
 
 .PHONY: requirements
 requirements: virtualenv .clone_st2_repo .install-runners

--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -124,6 +124,12 @@ packs-tests: requirements .clone_st2_repo .packs-tests
 		echo "==========================================================="; \
         (. $(VIRTUALENV_DIR)/bin/activate; cd $$component; python setup.py develop); \
 	done
+	@echo ""
+	@echo "================== register metrics drivers ======================"
+	@echo ""
+
+        # Install st2common to register metrics drivers
+        (cd ${ROOT_DIR}/st2common; ${ROOT_DIR}/$(VIRTUALENV_DIR)/bin/python setup.py develop)
 
 .PHONY: requirements
 requirements: virtualenv .clone_st2_repo .install-runners

--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -129,7 +129,7 @@ packs-tests: requirements .clone_st2_repo .packs-tests
 	@echo ""
 
         # Install st2common to register metrics drivers
-        (cd ${ROOT_DIR}/st2common; ${ROOT_DIR}/$(VIRTUALENV_DIR)/bin/python setup.py develop)
+        (. $(VIRTUALENV_DIR)/bin/activate; cd $(ST2_REPO_PATH)/st2common; python setup.py develop)
 
 .PHONY: requirements
 requirements: virtualenv .clone_st2_repo .install-runners


### PR DESCRIPTION
Added step to register metrics drivers. Tested it [here](https://circleci.com/gh/StackStorm-Exchange/stackstorm-mssql/28) with MSSQL pack, pulling this branch of ci repo. That passes OK.

This could be broken out as a separate item in the Makefile. Was just a PoC at this stage. @Kami will leave it to you to decide how best to implement it.