### PR TITLE
Reduce noise during "Run Tests" Circle CI build step

### DIFF
--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -19,6 +19,9 @@ COMPONENTS_RUNNERS := $(wildcard /tmp/st2/contrib/runners/*)
 .PHONY: all
 all: requirements lint packs-resource-register packs-tests
 
+.PHONY: all-ci
+all-ci: .flake8 .pylint .copy-pack-to-subdirectory .configs-check .metadata-check .packs-resource-register .packs-tests
+
 .PHONY: lint
 lint: requirements flake8 pylint configs-check metadata-check
 
@@ -136,6 +139,15 @@ packs-tests: requirements .clone_st2_repo .packs-tests
 requirements: virtualenv .clone_st2_repo .install-runners
 	@echo
 	@echo "==================== requirements ===================="
+	@echo
+	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=9.0,<9.1"
+	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache -q -r $(CI_DIR)/.circle/requirements-dev.txt
+	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache -q -r $(CI_DIR)/.circle/requirements-pack-tests.txt
+
+.PHONY: requirements-ci
+requirements-ci:
+	@echo
+	@echo "==================== requirements-ci ===================="
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=9.0,<9.1"
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache -q -r $(CI_DIR)/.circle/requirements-dev.txt

--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -106,7 +106,8 @@ packs-tests: requirements .clone_st2_repo .packs-tests
 	if [ ! "${CHANGED_FILES}" ]; then echo "No files have changed, skipping run..."; else (st2-check-print-pack-tests-coverage $(ROOT_DIR) || exit 1); fi;
 
 .PHONY: .clone_st2_repo
-.clone_st2_repo:
+.clone_st2_repo: /tmp/st2
+/tmp/st2:
 	@echo
 	@echo "==================== cloning st2 repo ===================="
 	@echo

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -2,7 +2,10 @@
 
 set -e
 
-my_dir="$(dirname "$0")"
+CURRENT_DIR="$(dirname "$0")"
+
+export CI_DIR=/home/circleci/ci
+export PYTHONPATH=/tmp/st2/st2common:${PYTHONPATH}
 
 git config --global user.name "StackStorm Exchange"
 git config --global user.email "info@stackstorm.com"
@@ -24,10 +27,24 @@ sudo apt-get -y install python-dev jq gmic optipng
 sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv
 
 virtualenv ~/virtualenv
-. ~/virtualenv/bin/activate
+source ~/virtualenv/bin/activate
 
 # Install StackStorm requirements
+echo "Installing StackStorm requirements from /tmp/st2/requirements.txt"
 ~/virtualenv/bin/pip install -r "/tmp/st2/requirements.txt"
 
+# Copy over Makefile and  install StackStorm runners and register metrics drivers
+echo "Installing StackStorm runners and registering metrics drivers"
+if [ ! -z "${ROOT_DIR}" ]; then
+    cp ~/ci/.circle/Makefile ${ROOT_DIR}
+    make -C requirements-ci .install-runners
+else
+    cp ~/ci/.circle/Makefile .
+    make requirements-ci .install-runners
+fi
+
 # Install pack requirements
-~/virtualenv/bin/pip install -r "$my_dir/requirements.txt"
+if [ -f "${CURRENT_DIR}/requirements.txt" ]; then
+    echo "Installing pack requirements from ${CURRENT_DIR}/requirements.txt"
+    ~/virtualenv/bin/pip install -r "${CURRENT_DIR}/requirements.txt"
+fi

--- a/.circle/test
+++ b/.circle/test
@@ -41,11 +41,9 @@ echo "FORCE_CHECK_ALL_FILES=${FORCE_CHECK_ALL_FILES}"
 
 if [ ! -z "${ROOT_DIR}" ]; then
     export ROOT_DIR="${ROOT_DIR}"
-    cp ~/ci/.circle/Makefile ${ROOT_DIR}
-    make -C ${ROOT_DIR} all
+    make -C ${ROOT_DIR} all-ci
 else
-    cp ~/ci/.circle/Makefile .
-    make all
+    make all-ci
 fi
 
 EXIT_CODE=$?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
             ~/ci/.circle/dependencies
       - run:
-          name: Run Tests
+          name: Run Lint Checks and Tests
           command: ~/ci/.circle/test
       - save_cache:
           key: v1-dependency-cache-{{ checksum "requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,12 @@ jobs:
       - restore_cache:
           key: v1-dependency-cache-{{ checksum "requirements.txt" }}
       - run:
-          name: Download dependencies
+          name: Download and Install Dependencies
           command: |
             git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
             ~/ci/.circle/dependencies
       - run:
-          name: Run tests
+          name: Run Tests
           command: ~/ci/.circle/test
       - save_cache:
           key: v1-dependency-cache-{{ checksum "requirements.txt" }}


### PR DESCRIPTION
This pull request improves the output generated during "Dependencies" and "Run Tests" steps which run on each Circle CI build.

We have two main steps inside our pack build workflow - one to install the dependencies and the other one to run all the various (lint) checks and pack tests.

Before this change we actually installed dependencies in two places - inside "dependencies" step and also inside "run tests" step.

This meant that "Run Tests" step produced a lot of dependency installation related output which made actual "valuable" lint check and test output hard to spot.

And not to mention that it was confusing that the dependencies were installed in multiple places.

I added a new Make target and left "all" target as is, because the idea is that you can also use this ``Makefile`` with your project so it works out of the box outside our Circle CI build environment.

Before: https://circleci.com/gh/StackStorm-Exchange/stackstorm-mssql/28
After: https://circleci.com/gh/StackStorm-Exchange/stackstorm-mssql/36