### PR TITLE
Add support for Python 3.x checks to pack Circle CI config

### DIFF
--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -20,7 +20,7 @@ COMPONENTS_RUNNERS := $(wildcard /tmp/st2/contrib/runners/*)
 all: requirements lint packs-resource-register packs-tests
 
 .PHONY: all-ci
-all-ci: .flake8 .pylint .copy-pack-to-subdirectory .configs-check .metadata-check .packs-resource-register .packs-tests
+all-ci: .compile .flake8 .pylint .copy-pack-to-subdirectory .configs-check .metadata-check .packs-resource-register .packs-tests
 
 .PHONY: lint
 lint: requirements flake8 pylint configs-check metadata-check
@@ -53,6 +53,12 @@ packs-missing-tests: requirements .packs-missing-tests
 
 .PHONY: packs-tests
 packs-tests: requirements .clone_st2_repo .packs-tests
+
+.PHONY: .compile
+.compile:
+	@echo "======================= compile ========================"
+	@echo "------- Compile all .py files (syntax check test) ------"
+	@if python -c 'import compileall,re; compileall.compile_dir(".", rx=re.compile(r"/virtualenv|virtualenv-osx|virtualenv-py3|.tox|.git|.venv-st2devbox"), quiet=True)' | grep .; then exit 1; else exit 0; fi
 
 .PHONY: .flake8
 .flake8:

--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -58,7 +58,7 @@ packs-tests: requirements .clone_st2_repo .packs-tests
 .compile:
 	@echo "======================= compile ========================"
 	@echo "------- Compile all .py files (syntax check test) ------"
-	@if python -c 'import compileall,re; compileall.compile_dir(".", rx=re.compile(r"/virtualenv|virtualenv-osx|virtualenv-py3|.tox|.git|.venv-st2devbox"), quiet=True)' | grep .; then exit 1; else exit 0; fi
+	if python -c 'import compileall,re; compileall.compile_dir(".", rx=re.compile(r"/virtualenv|virtualenv-osx|virtualenv-py3|.tox|.git|.venv-st2devbox"), quiet=True)' | grep .; then exit 1; else exit 0; fi
 
 .PHONY: .flake8
 .flake8:

--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -20,7 +20,7 @@ COMPONENTS_RUNNERS := $(wildcard /tmp/st2/contrib/runners/*)
 all: requirements lint packs-resource-register packs-tests
 
 .PHONY: all-ci
-all-ci: .compile .flake8 .pylint .copy-pack-to-subdirectory .configs-check .metadata-check .packs-resource-register .packs-tests
+all-ci: compile .flake8 .pylint .copy-pack-to-subdirectory .configs-check .metadata-check .packs-resource-register .packs-tests
 
 .PHONY: lint
 lint: requirements flake8 pylint configs-check metadata-check
@@ -54,8 +54,8 @@ packs-missing-tests: requirements .packs-missing-tests
 .PHONY: packs-tests
 packs-tests: requirements .clone_st2_repo .packs-tests
 
-.PHONY: .compile
-.compile:
+.PHONY: compile
+compile:
 	@echo "======================= compile ========================"
 	@echo "------- Compile all .py files (syntax check test) ------"
 	if python -c 'import compileall,re; compileall.compile_dir(".", rx=re.compile(r"/virtualenv|virtualenv-osx|virtualenv-py3|.tox|.git|.venv-st2devbox"), quiet=True)' | grep .; then exit 1; else exit 0; fi

--- a/.circle/circle.yml.sample
+++ b/.circle/circle.yml.sample
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  build_and_test:
+  build_and_test_python27:
     docker:
       - image: circleci/python:2.7
       - image: rabbitmq:3
@@ -15,17 +15,54 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-dependency-cache-{{ checksum "requirements.txt" }}
+          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
       - run:
           name: Download dependencies
           command: |
             git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
             ~/ci/.circle/dependencies
       - run:
-          name: Run tests
+          name: Run tests (Python 2.7)
           command: ~/ci/.circle/test
       - save_cache:
-          key: v1-dependency-cache-{{ checksum "requirements.txt" }}
+          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
+          paths:
+            - ~/.cache/pip
+            - ~/.apt-cache
+      - persist_to_workspace:
+          root: /
+          paths:
+            - home/circleci/ci
+            - home/circleci/virtualenv
+            - tmp/st2
+            - home/circleci/repo
+            - home/circleci/.gitconfig
+
+  build_and_test_python36:
+    docker:
+      - image: circleci/python:3.6
+      - image: rabbitmq:3
+      - image: mongo:3.4
+
+    working_directory: ~/repo
+
+    environment:
+      VIRTUALENV_DIR: "~/virtualenv"
+
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
+      - run:
+          name: Download dependencies
+          command: |
+            git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
+            ~/ci/.circle/dependencies
+      - run:
+          name: Run tests (Python 3.6)
+          command: ~/ci/.circle/test
+      - save_cache:
+          key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
           paths:
             - ~/.cache/pip
             - ~/.apt-cache
@@ -64,10 +101,11 @@ workflows:
   version: 2
   build_test_deploy:
     jobs:
-      - build_and_test
+      - build_and_test_python27
+      - build_and_test_python36
       - deploy:
           requires:
-            - build_and_test
+            - build_and_test_python27
           filters:
             branches:
               only: master

--- a/.circle/circle.yml.sample
+++ b/.circle/circle.yml.sample
@@ -38,6 +38,9 @@ jobs:
             - home/circleci/repo
             - home/circleci/.gitconfig
 
+  # NOTE: Until we add "python_version" metadata attribute to pack.yaml and
+  # explicitly call which packs work with Python 3.x, Python 3.x failures are
+  # not considered fatal
   build_and_test_python36:
     docker:
       - image: circleci/python:3.6
@@ -60,7 +63,7 @@ jobs:
             ~/ci/.circle/dependencies
       - run:
           name: Run tests (Python 3.6)
-          command: ~/ci/.circle/test
+          command: ~/ci/.circle/test || exit 0
       - save_cache:
           key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
           paths:

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -40,9 +40,11 @@ echo "Installing StackStorm requirements from /tmp/st2/requirements.txt"
 # Copy over Makefile and  install StackStorm runners and register metrics drivers
 echo "Installing StackStorm runners and registering metrics drivers"
 if [ ! -z "${ROOT_DIR}" ]; then
+    echo "Copying Makefile to ${ROOT_DIR}"
     cp ~/ci/.circle/Makefile ${ROOT_DIR}
     make -C requirements-ci .install-runners
 else
+    echo "Copying Makefile to $(pwd)"
     cp ~/ci/.circle/Makefile .
     make requirements-ci .install-runners
 fi

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -10,6 +10,10 @@ export PYTHONPATH=/tmp/st2/st2common:${PYTHONPATH}
 git config --global user.name "StackStorm Exchange"
 git config --global user.email "info@stackstorm.com"
 
+# Print out environment info
+python --version
+pip --version
+
 # Clone st2 repo so other scripts can reference StackStorm Python code
 git clone --depth 1 --single-branch --branch master https://github.com/StackStorm/st2.git /tmp/st2
 


### PR DESCRIPTION
This pull request adds support for running various lint checks and pack tests under Python 3.6 (in addition to Python 2.7).

In addition to new Python 3 checks, I also added new "compile" check for Python 2.7 and Python 3.6 job which verifies Python syntax in pack files is valid.

A couple of things to keep in mind:

1. For the time being, we will run those checks on all the packs, but won't consider Python 3.x check and test failures as fatal (aka failing the build).
This will allow us to identify "problematic" packs. The goal is to add new ``python_version`` attribute to ``pack.yaml`` file and utilize that attribute in CI to determine if pack supports Python 3. For packs which claim support for Python 3, build will fail if Python 3 checks fail, and for ones which don't, it wont (will open a PR for that in StackStorm/st2 shortly).
2. Needed to make small change to script in ``st2sdk`` because CI scripts use StackStorm from git checkout and all the shebangs in scripts in the repo explicitly default to python2.7 binary.

## TODO

- [x] Publish new version of st2sdk to PyPi
- [x] Fix CI in st2sdk
- [ ] Update all packs to use this new Circle CI config
