### PR TITLE
Treat Python 3 check and test failures as fatal for packs which claim Python 3 support

### DIFF
--- a/.circle/circle.yml.sample
+++ b/.circle/circle.yml.sample
@@ -65,7 +65,7 @@ jobs:
             ~/ci/.circle/dependencies
       - run:
           name: Run tests (Python 3.6)
-          command: ~/ci/.circle/test || exit 0
+          command: ~/ci/.circle/test ; ~/ci/.circle/exit_on_py3_checks
       - save_cache:
           key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
           paths:

--- a/.circle/exit_on_py3_checks
+++ b/.circle/exit_on_py3_checks
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Script which checks exit code of "test" script under Python 3.6 environment
+# and exists with an appropriate code
+TEST_EXIT_CODE=$1
+
+echo "Original script exit code: ${TEST_EXIT_CODE}"
+
+# If pack doesnt' declare Python 3 support, we don't treat failures as fatal
+SUPPORTS_PYTHON3=$(python -c $'import yaml, sys\nresult = yaml.safe_load(open("pack.yaml", "r").read())\nif "3" in result.get("python_versions", []):\n    print("yes")')
+
+if [ "${SUPPORTS_PYTHON3}" != "yes" ] && [ ${TEST_EXIT_CODE} -ne 0 ] ; then
+    echo "Ignoring failures since pack doesn't declare Python 3 support in pack.yaml"
+    exit 0
+fi
+
+exit ${TEST_EXIT_CODE}


### PR DESCRIPTION
This pull request updates sample pack Circle CI config so Python 3 build failures as treated as fatal for any pack which claims Python 3 support in pack.yaml file.