### PR TITLE
Fix a few things

### DIFF
--- a/.circle/requirements-pack-tests.txt
+++ b/.circle/requirements-pack-tests.txt
@@ -1,4 +1,4 @@
-mock>=1.3.0,<2.0
+mock>=1.3.0,<2.1
 unittest2>=1.1.0,<2.0
 nose>=1.3.7
 # temporary workaround for travis issue

--- a/.circle/validate.py
+++ b/.circle/validate.py
@@ -27,7 +27,7 @@ PACK_SCHEMA = PackAPI.schema
 
 def load_yaml_file(path):
     with open(path, 'r') as stream:
-        text = yaml.load(stream)
+        text = yaml.safe_load(stream)
 
     return text
 


### PR DESCRIPTION
* Use `yaml.safe_load` instead of `yaml.load`, just to avoid a warning.
* Install Mock v2.0.0 so CI can use [`Mock.assert_called_once`](https://github.com/testing-cabal/mock/blob/2.0.0/NEWS#L4) (StackStorm-Exchange/stackstorm-nexus3#1)