### PR TITLE
Upgrade lint dependency versions so the match versions in StackStorm/st2 repo

### DIFF
--- a/.circle/requirements-dev.txt
+++ b/.circle/requirements-dev.txt
@@ -4,4 +4,4 @@ pyyaml
 pep8>=1.6.0,<1.7
 flake8==3.7.7
 astroid==1.6.5
-pylint==1.9.3
+pylint==1.9.4

--- a/.circle/requirements-dev.txt
+++ b/.circle/requirements-dev.txt
@@ -2,6 +2,6 @@
 -e git+https://github.com/StackStorm/st2sdk.git@master#egg=st2sdk
 pyyaml
 pep8>=1.6.0,<1.7
-flake8>=3.5.0,<3.6
-astroid==1.5.3
-pylint==1.7.4
+flake8==3.7.7
+astroid==1.6.5
+pylint==1.9.3


### PR DESCRIPTION
This pull request updates lint dependency versions (flake8, pylint) so they match versions used in StackStorm/st2 repo.

Those new versions might identify some new issues on new (weekly) CI runs which may need to be fixed for the builds to pass again.