### PR TITLE
Include available versions for all the packs in the index

### DIFF
--- a/.circle/deployment
+++ b/.circle/deployment
@@ -20,12 +20,38 @@ fi
 
 # TODO: figure out how to make deploy.py rebuild the index.
 # python ~/packs/.circle/deploy.py pack.yaml "${CIRCLE_PROJECT_REPONAME}"
+
 # Clean up so the script can be retries in case of failure (e.g. race)
 rm -rf ~/index
 git clone https://${MACHINE_USER}:${MACHINE_PASSWORD}@github.com/StackStorm-Exchange/index ~/index 2>/dev/null
 
 echo "Processing pack ${PACK_NAME}"
 
+# NOTE: We create tags before re-building the index to ensure latest tag is reflected in the index
+
+# Create version tags
+METADATA_CHANGES=$(git rev-list --all --no-abbrev --remove-empty -- pack.yaml)
+for COMMIT in $(echo $METADATA_CHANGES)
+do
+  git checkout ${COMMIT} pack.yaml > /dev/null
+  VERSION=$(~/virtualenv/bin/python ~/ci/.circle/semver.py pack.yaml 2>/dev/null || true)
+
+  # 1. Create a tag if version is specified and tag doesn't exist locally
+  if [[ ${VERSION} ]] && [[ -z $(git rev-parse -q --verify "refs/tags/v${VERSION}") ]]
+  then
+    echo "Creating tag ${VERSION} for commit ${COMMIT}"
+    git tag v${VERSION} ${COMMIT}
+  fi
+
+  # 2. If version is specified and tag doesn't exist on the remote, push it
+  if [[ ${VERSION} ]] && [[ -z $(git ls-remote origin "refs/tags/v${VERSION}") ]]
+  then
+    echo "Pushing tag v${VERSION} to origin remote"
+    git push origin v${VERSION}
+  fi
+done
+
+# Rebuild pack index directory
 ~/virtualenv/bin/python ~/ci/utils/pack_content.py --input . --output ~/index/v1/packs/"${PACK_NAME}"
 
 # Rebuild the index JSON
@@ -57,7 +83,6 @@ git -C ~/index status
 
 if ! git -C ~/index diff --quiet --exit-code --cached
 then
-
   echo "Updating the index repo..."
   git -C ~/index commit -m "Update the ${PACK_NAME} pack."
   git -C ~/index push origin 2>/dev/null
@@ -73,25 +98,3 @@ then
 else
   echo "No changes to pack metadata, skipping the index update."
 fi
-
-# Create version tags
-METADATA_CHANGES=$(git rev-list --all --no-abbrev --remove-empty -- pack.yaml)
-for COMMIT in $(echo $METADATA_CHANGES)
-do
-  git checkout ${COMMIT} pack.yaml > /dev/null
-  VERSION=$(~/virtualenv/bin/python ~/ci/.circle/semver.py pack.yaml 2>/dev/null || true)
-
-  # 1. Create a tag if version is specified and tag doesn't exist locally
-  if [[ ${VERSION} ]] && [[ -z $(git rev-parse -q --verify "refs/tags/v${VERSION}") ]]
-  then
-    echo "Creating tag ${VERSION} for commit ${COMMIT}"
-    git tag v${VERSION} ${COMMIT}
-  fi
-
-  # 2. If version is specified and tag doesn't exist on the remote, push it
-  if [[ ${VERSION} ]] && [[ -z $(git ls-remote origin "refs/tags/v${VERSION}") ]]
-  then
-    echo "Pushing tag v${VERSION} to origin remote"
-    git push origin v${VERSION}
-  fi
-done

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -99,7 +99,9 @@ def get_tags_for_pack(pack_ref):
 
     for item in resp.json():
         if item.get('name', None).startswith('v'):
-            tags.append(item['name'])
+            tags.append(item['name'].replace('v', ''))
+
+    tags = list(reversed(sorted(tags)))
 
     return tags
 

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -16,7 +16,11 @@ from st2common.util.pack import get_pack_ref_from_metadata
 EXCHANGE_NAME = "StackStorm-Exchange"
 EXCHANGE_PREFIX = "stackstorm"
 
+GITHUB_USERNAME = os.environ.get('GITHUB_USERNAME')
+GITHUB_PASSWORD = os.environ.get('GITHUB_PASSWORD')
+
 SESSION = requests.Session()
+SESSION.auth = (GITHUB_USERNAME, GITHUB_PASSWORD)
 
 
 def build_index(path_glob, output_path):

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -52,10 +52,10 @@ def build_index(path_glob, output_path):
             EXCHANGE_NAME, EXCHANGE_PREFIX, sanitized_pack_name
         )
 
-        tags = get_tags_for_pack(pack_ref)
+        versions = get_available_versions_for_pack(pack_ref)
 
-        if tags is not None:
-            pack_meta['tags'] = tags
+        if versions is not None:
+            pack_meta['versions'] = versions
 
         # Note: Key in the index dictionary is ref and not a name
         result['packs'][pack_ref] = pack_meta
@@ -81,9 +81,9 @@ def build_index(path_glob, output_path):
     print('Index data written to "%s".' % (output_path))
 
 
-def get_tags_for_pack(pack_ref):
+def get_available_versions_for_pack(pack_ref):
     """
-    Retrieve all the available tags for a particular pack.
+    Retrieve all the available versions for a particular pack.
 
     NOTE: This function uses Github API.
     """
@@ -95,15 +95,15 @@ def get_tags_for_pack(pack_ref):
         print('Got non 200 response: %s' % (resp.text))
         return None
 
-    tags = []
+    versions = []
 
     for item in resp.json():
         if item.get('name', None).startswith('v'):
-            tags.append(item['name'].replace('v', ''))
+            versions.append(item['name'].replace('v', ''))
 
-    tags = list(reversed(sorted(tags)))
+    versions = list(reversed(sorted(versions)))
 
-    return tags
+    return versions
 
 
 if __name__ == '__main__':

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -98,7 +98,7 @@ def get_available_versions_for_pack(pack_ref):
     versions = []
 
     for item in resp.json():
-        if item.get('name', None).startswith('v'):
+        if item.get('name', '').startswith('v'):
             versions.append(item['name'].replace('v', ''))
 
     versions = list(reversed(sorted(versions)))

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -52,7 +52,10 @@ def build_index(path_glob, output_path):
             EXCHANGE_NAME, EXCHANGE_PREFIX, sanitized_pack_name
         )
 
-        pack_meta['tags'] = get_tags_for_pack(pack_ref)
+        tags = get_tags_for_pack(pack_ref)
+
+        if tags is not None:
+            pack_meta['tags'] = tags
 
         # Note: Key in the index dictionary is ref and not a name
         result['packs'][pack_ref] = pack_meta
@@ -90,7 +93,7 @@ def get_tags_for_pack(pack_ref):
 
     if resp.status_code != 200:
         print('Got non 200 response: %s' % (resp.text))
-        return []
+        return None
 
     tags = []
 

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -16,8 +16,8 @@ from st2common.util.pack import get_pack_ref_from_metadata
 EXCHANGE_NAME = "StackStorm-Exchange"
 EXCHANGE_PREFIX = "stackstorm"
 
-GITHUB_USERNAME = os.environ.get('GITHUB_USERNAME')
-GITHUB_PASSWORD = os.environ.get('GITHUB_PASSWORD')
+GITHUB_USERNAME = os.environ.get('MACHINE_USER')
+GITHUB_PASSWORD = os.environ.get('MACHINE_PASSWORD')
 
 SESSION = requests.Session()
 SESSION.auth = (GITHUB_USERNAME, GITHUB_PASSWORD)


### PR DESCRIPTION
This pull request updates generate index script so we now also include all the available versions for each pack in the index.json file.

## Implementation

This implementation utilizes Github API to retrieve all the available tags for a particular pack repo.

## TODO

- [x] Handle Github authentication so we get a higher rate limit