### PR TITLE
Fix index bug

### DIFF
--- a/.circle/deployment
+++ b/.circle/deployment
@@ -54,6 +54,10 @@ done
 # Afer pushing the version, make sure we check out the latest commit
 # This is important so index reflects latest changes
 git checkout master
+git reset --hard master
+
+# Verify there are no unstaged changes
+git status
 
 # Rebuild pack index directory
 ~/virtualenv/bin/python ~/ci/utils/pack_content.py --input . --output ~/index/v1/packs/"${PACK_NAME}"

--- a/.circle/deployment
+++ b/.circle/deployment
@@ -51,6 +51,10 @@ do
   fi
 done
 
+# Afer pushing the version, make sure we check out the latest commit
+# This is important so index reflects latest changes
+git checkout master
+
 # Rebuild pack index directory
 ~/virtualenv/bin/python ~/ci/utils/pack_content.py --input . --output ~/index/v1/packs/"${PACK_NAME}"
 

--- a/.circle/semver.py
+++ b/.circle/semver.py
@@ -34,6 +34,5 @@ def get_semver_string(version):
         raise ValueError("Cannot convert %s to semver." % version)
 
 if __name__ == '__main__':
-
     pack = validate.load_yaml_file(sys.argv[1])
-    print get_semver_string(pack['version'])
+    print(get_semver_string(pack['version']))


### PR DESCRIPTION
This pull request fixes a bug inadvertently introduced in #72.

Index incorrectly started picking up old versions - https://github.com/StackStorm-Exchange/index/commit/f56625926604c37cd50cad6f19c1c91cf82dfa49.

The bug was related to the code re-org I did. I reorganized the code so we create version tags before we create the index.

As part of the tag creating process, we check out every tag (from newest to oldest). To fix the issue, we need to switch back to the latest commit (master) after processing the tag.