### PR TITLE
Configurable checkouts

### DIFF
--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -15,10 +15,10 @@ python --version
 pip --version
 
 # Clone st2 repo so other scripts can reference StackStorm Python code
-git clone --depth 1 --single-branch --branch master https://github.com/StackStorm/st2.git /tmp/st2
+git clone --depth 1 --single-branch --branch ${ST2_BRANCH} https://github.com/StackStorm/st2.git /tmp/st2
 
 # Clone lint-configs
-git clone --depth 1 --single-branch --branch master https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
+git clone --depth 1 --single-branch --branch ${LINT_CONFIGS_BRANCH} https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
 
 # Create a directory for debian packages so we can cache it in Circle CI
 sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives && mkdir -p ~/.apt-cache/partial

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -7,6 +7,9 @@ CURRENT_DIR="$(dirname "$0")"
 export CI_DIR=/home/circleci/ci
 export PYTHONPATH=/tmp/st2/st2common:${PYTHONPATH}
 
+ST2_BRANCH=${ST2_BRANCH:-master}
+LINT_CONFIGS_BRANCH=${LINT_CONFIGS_BRANCH:-master}
+
 git config --global user.name "StackStorm Exchange"
 git config --global user.email "info@stackstorm.com"
 
@@ -15,10 +18,10 @@ python --version
 pip --version
 
 # Clone st2 repo so other scripts can reference StackStorm Python code
-git clone --depth 1 --single-branch --branch ${ST2_BRANCH:-master} https://github.com/StackStorm/st2.git /tmp/st2
+git clone --depth 1 --single-branch --branch "${ST2_BRANCH}" https://github.com/StackStorm/st2.git /tmp/st2
 
 # Clone lint-configs
-git clone --depth 1 --single-branch --branch ${LINT_CONFIGS_BRANCH:-master} https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
+git clone --depth 1 --single-branch --branch "${LINT_CONFIGS_BRANCH}" https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
 
 # Create a directory for debian packages so we can cache it in Circle CI
 sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives && mkdir -p ~/.apt-cache/partial

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -15,10 +15,10 @@ python --version
 pip --version
 
 # Clone st2 repo so other scripts can reference StackStorm Python code
-git clone --depth 1 --single-branch --branch ${ST2_BRANCH} https://github.com/StackStorm/st2.git /tmp/st2
+git clone --depth 1 --single-branch --branch ${ST2_BRANCH:-master} https://github.com/StackStorm/st2.git /tmp/st2
 
 # Clone lint-configs
-git clone --depth 1 --single-branch --branch ${LINT_CONFIGS_BRANCH} https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
+git clone --depth 1 --single-branch --branch ${LINT_CONFIGS_BRANCH:-master} https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
 
 # Create a directory for debian packages so we can cache it in Circle CI
 sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives && mkdir -p ~/.apt-cache/partial


### PR DESCRIPTION
This PR tweaks the `dependencies` script to use environment variables to specify the branches of ST2 and lint-configs to checkout. I maintain reverse compatibility by using Bash magic (eg: variable references) to default to the `master` branch if the environment variables are not defined.

This is useful for when you are working on fixing failing pack CIs and you want to test out some changes to, for instance, [the `st2-run-pack-tests` script from the st2 repository](https://github.com/StackStorm/st2/pull/4790). This should make it easier and faster to test out changes to the CI scripts for failing packs.

Before this PR, you had to rerun a failed CircleCI workflow with SSH, SSH in, tweak the `dependencies` script yourself (or manually checkout a different branch of st2 or lint-configs), and rerun the tests. With this PR, you just have to set environment variables in the CircleCI configuration and rerun the failed workflow.