### PR TITLE
[SECURITY] Use PyYAML's yaml.safe_load when loading YAML files

### DIFF
--- a/.circle/index.py
+++ b/.circle/index.py
@@ -40,7 +40,7 @@ def build_index(path_glob, output_path):
     counter = 0
     for filename in generator:
         with open(filename, 'r') as pack:
-            pack_meta = yaml.load(pack)
+            pack_meta = yaml.safe_load(pack)
 
         pack_name = pack_meta['name']
         pack_ref = get_pack_ref_from_metadata(metadata=pack_meta)

--- a/utils/pack_content.py
+++ b/utils/pack_content.py
@@ -55,7 +55,7 @@ def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
     OrderedLoader.add_constructor(
         yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
         construct_mapping)
-    return yaml.load(stream, OrderedLoader)
+    return yaml.safe_load(stream, OrderedLoader)
 
 
 def ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):


### PR DESCRIPTION
I immediately merged this PR just in case there is a CircleCI config somewhere that is vulnerable.

This fixes a security flaw where PyYAML could unsafely read a YAML file. So a malicious user _may_ have been able to craft a malicious YAML file, commit it, push it, and create a pull request. Then the CircleCI task would have unsafely loaded the malicious file. This could have happened on **any** pack on StackStorm-Exchange.

With this PR, the YAML file is now safely loaded.