### PR TITLE
Turn off python3 checks

### DIFF
--- a/.circle/exit_on_py2_checks
+++ b/.circle/exit_on_py2_checks
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Script which checks exit code of "test" script under Python 2.7 environment
+# and exists with an appropriate code
+if [ $# -lt 1 ] ; then
+    echo "Usage: $0 <test script exit code>"
+    echo "Example: $0 1"
+    exit 2
+fi
+
+TEST_EXIT_CODE=$1
+
+echo "Original script exit code: ${TEST_EXIT_CODE}"
+
+# If pack doesn't declare Python 2 support, we don't treat failures as fatal
+SUPPORTS_PYTHON2=$(~/virtualenv/bin/python -c $'import yaml, sys\nresult = yaml.safe_load(open("pack.yaml", "r").read())\nif "2" in result.get("python_versions", []):\n    print("yes")')
+
+if [ "${SUPPORTS_PYTHON2}" != "yes" ] && [ ${TEST_EXIT_CODE} -ne 0 ] ; then
+    echo "Ignoring failures since pack doesn't declare Python 2 support in pack.yaml"
+    exit 0
+fi
+
+exit ${TEST_EXIT_CODE}

--- a/.circle/exit_on_py3_checks
+++ b/.circle/exit_on_py3_checks
@@ -12,6 +12,12 @@ TEST_EXIT_CODE=$1
 
 echo "Original script exit code: ${TEST_EXIT_CODE}"
 
-echo "Exiting with original script exit code (forcing Python 3 build failures)"
+# If pack doesn't declare Python 3 support, we don't treat failures as fatal
+SUPPORTS_PYTHON3=$(~/virtualenv/bin/python -c $'import yaml, sys\nresult = yaml.safe_load(open("pack.yaml", "r").read())\nif "3" in result.get("python_versions", []):\n    print("yes")')
+
+if [ "${SUPPORTS_PYTHON3}" != "yes" ] && [ ${TEST_EXIT_CODE} -ne 0 ] ; then
+    echo "Ignoring failures since pack doesn't declare Python 3 support in pack.yaml"
+    exit 0
+fi
 
 exit ${TEST_EXIT_CODE}


### PR DESCRIPTION
Reverts #81 (and fixes a typo).

Also adds support for packs that do _not_ declare Python 2 support, like the very forward looking [stackstorm-fortinet](https://github.com/StackStorm-Exchange/stackstorm-fortinet/blob/master/pack.yaml#L12).