### PR TITLE
Add CI to ci repo

### DIFF
--- a/.circle/deploy.py
+++ b/.circle/deploy.py
@@ -54,11 +54,12 @@ def calculate_git_sha(content):
     sha.update('blob {}\0{}'.format(len(content), content))
     return sha.hexdigest()
 
+
 if __name__ == '__main__':
     local_path = sys.argv[1]
     pack_name = sys.argv[2]
 
-    with file(local_path) as f:
+    with open(local_path) as f:
         content = f.read()
 
     current_pack_meta = get_file(pack_name)

--- a/.circle/deploy.py
+++ b/.circle/deploy.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 
 import base64
 import hashlib

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import argparse
 import hashlib

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
-import os
-import json
-import yaml
-import time
 import argparse
 import hashlib
+import json
+import os
+import time
 from glob import glob
 from collections import OrderedDict
+import yaml
 
 import requests
 

--- a/.circle/requirements-ci-ci.txt
+++ b/.circle/requirements-ci-ci.txt
@@ -1,0 +1,4 @@
+flake8
+pylint
+pyyaml
+requests

--- a/.circle/semver.py
+++ b/.circle/semver.py
@@ -18,20 +18,28 @@ import re
 
 import validate
 
-SEMVER_REGEX = "^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?$"
-SINGLE_VERSION_REGEX = "^\d+$"
-DOUBLE_VERSION_REGEX = "^\d+\.\d+$"
+SEMVER_REGEX = re.compile(r"""^(?:0|[1-9]\d*)
+                              \.
+                              (?:0|[1-9]\d*)
+                              \.
+                              (?:0|[1-9]\d*)
+                              (?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?
+                              (?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?$""",
+                          re.VERBOSE)
+SINGLE_VERSION_REGEX = re.compile(r"^\d+$")
+DOUBLE_VERSION_REGEX = re.compile(r"^\d+\.\d+$")
 
 
 def get_semver_string(version):
-    if re.match(SINGLE_VERSION_REGEX, str(version)):
+    if SINGLE_VERSION_REGEX.match(str(version)):
         return "%s.0.0" % version
-    elif re.match(DOUBLE_VERSION_REGEX, str(version)):
+    elif DOUBLE_VERSION_REGEX.match(str(version)):
         return "%s.0" % version
-    elif re.match(SEMVER_REGEX, version):
+    elif SEMVER_REGEX.match(version):
         return version
     else:
         raise ValueError("Cannot convert %s to semver." % version)
+
 
 if __name__ == '__main__':
     pack = validate.load_yaml_file(sys.argv[1])

--- a/.circle/semver.py
+++ b/.circle/semver.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 
 import sys
 import re

--- a/.circle/semver.py
+++ b/.circle/semver.py
@@ -32,13 +32,14 @@ DOUBLE_VERSION_REGEX = re.compile(r"^\d+\.\d+$")
 
 def get_semver_string(version):
     if SINGLE_VERSION_REGEX.match(str(version)):
-        return "%s.0.0" % version
+        semver = "%s.0.0" % version
     elif DOUBLE_VERSION_REGEX.match(str(version)):
-        return "%s.0" % version
+        semver = "%s.0" % version
     elif SEMVER_REGEX.match(version):
-        return version
+        semver = version
     else:
         raise ValueError("Cannot convert %s to semver." % version)
+    return semver
 
 
 if __name__ == '__main__':

--- a/.circle/validate.py
+++ b/.circle/validate.py
@@ -45,7 +45,7 @@ def validate_pack_contains_valid_ref_or_name(pack_meta):
 
 
 def validate_repo_name(instance, repo_name):
-    if '%s-%s' % (PREFIX, pack_meta['name']) != repo_name:
+    if '%s-%s' % (PREFIX, instance['name']) != repo_name:
         raise ValueError('Pack name is different from repository name.')
 
 
@@ -53,6 +53,8 @@ if __name__ == '__main__':
     repo_name = sys.argv[1]
     pack_meta = load_yaml_file(sys.argv[2])
 
+    # TODO: Figure out why this wasn't previously executed, and execute it
+    # validate_repo_name(pack_meta, repo_name)
     validate_schema(pack_meta, PACK_SCHEMA)
     pack_ref = validate_pack_contains_valid_ref_or_name(pack_meta)
 

--- a/.circle/validate.py
+++ b/.circle/validate.py
@@ -48,6 +48,7 @@ def validate_repo_name(instance, repo_name):
     if '%s-%s' % (PREFIX, pack_meta['name']) != repo_name:
         raise ValueError('Pack name is different from repository name.')
 
+
 if __name__ == '__main__':
     repo_name = sys.argv[1]
     pack_meta = load_yaml_file(sys.argv[2])

--- a/.circle/validate.py
+++ b/.circle/validate.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 
 import sys
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
 
     steps:
       - checkout
-      # - restore_cache:
-      #     key: v1-dependency-cache-{{ checksum "requirements.txt" }}
+      - restore_cache:
+          key: v1-dependency-cache-{{ checksum ".circle/requirements-ci-ci.txt" }}
       - run:
           name: Download and Install Dependencies
           command: |
@@ -24,6 +24,11 @@ jobs:
             sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv pyyaml
             virtualenv ~/virtualenv
             ~/virtualenv/bin/pip install flake8 pylint pyyaml requests
+      - save_cache:
+          key: v1-dependency-cache-{{ checksum ".circle/requirements-ci-ci.txt" }}
+          paths:
+            - ~/.cache/pip
+            - ~/.apt-cache
       - run:
           name: Check YAML file syntax
           command: >
@@ -48,11 +53,6 @@ jobs:
           name: Check Makefile syntax
           command: |
             find . -name Makefile | xargs make -n
-      # - save_cache:
-      #     key: v1-dependency-cache-{{ checksum "requirements.txt" }}
-      #     paths:
-      #       - ~/.cache/pip
-      #       - ~/.apt-cache
       # - persist_to_workspace:
       #     root: /
       #     paths:
@@ -71,8 +71,8 @@ jobs:
 
     steps:
       - checkout
-      # - restore_cache:
-      #     key: v1-dependency-cache-{{ checksum "requirements.txt" }}
+      - restore_cache:
+          key: v1-dependency-cache-{{ checksum ".circle/requirements-ci-ci.txt" }}
       - run:
           name: Download and Install Dependencies
           command: |
@@ -80,6 +80,11 @@ jobs:
             sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv pyyaml
             virtualenv ~/virtualenv
             ~/virtualenv/bin/pip install flake8 pylint pyyaml requests
+      - save_cache:
+          key: v1-dependency-cache-{{ checksum ".circle/requirements-ci-ci.txt" }}
+          paths:
+            - ~/.cache/pip
+            - ~/.apt-cache
       - run:
           name: Check YAML file syntax
           command: >
@@ -104,11 +109,6 @@ jobs:
           name: Check Makefile syntax
           command: |
             find . -name Makefile | xargs make -n
-      # - save_cache:
-      #     key: v1-dependency-cache-{{ checksum "requirements.txt" }}
-      #     paths:
-      #       - ~/.cache/pip
-      #       - ~/.apt-cache
       # - persist_to_workspace:
       #     root: /
       #     paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
             git clone --depth 1 --single-branch --branch "${LINT_CONFIGS_BRANCH:-master}" https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
             sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv pyyaml
             virtualenv ~/virtualenv
-            ~/virtualenv/bin/pip install flake8 pylint pyyaml
+            ~/virtualenv/bin/pip install flake8 pylint pyyaml requests
       - run:
           name: Check YAML file syntax
           command: >
@@ -82,7 +82,7 @@ jobs:
             git clone --depth 1 --single-branch --branch "${LINT_CONFIGS_BRANCH:-master}" https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
             sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv pyyaml
             virtualenv ~/virtualenv
-            ~/virtualenv/bin/pip install flake8 pylint pyyaml
+            ~/virtualenv/bin/pip install flake8 pylint pyyaml requests
       - run:
           name: Check YAML file syntax
           command: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       - image: circleci/python:2.7
 
-    working_directory: ~/repo
+    working_directory: ~/ci
 
     environment:
       VIRTUALENV_DIR: "~/virtualenv"
@@ -20,7 +20,6 @@ jobs:
       - run:
           name: Download and Install Dependencies
           command: |
-            git clone -b "${CI_BRANCH:-master}" git://github.com/stackstorm-exchange/ci.git ~/ci
             git clone --depth 1 --single-branch --branch "${LINT_CONFIGS_BRANCH:-master}" https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
             sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv pyyaml
             virtualenv ~/virtualenv
@@ -59,14 +58,13 @@ jobs:
       #     paths:
       #       - home/circleci/ci
       #       - home/circleci/virtualenv
-      #       - home/circleci/repo
       #       - home/circleci/.gitconfig
 
   test_py36:
     docker:
       - image: circleci/python:3.6
 
-    working_directory: ~/repo
+    working_directory: ~/ci
 
     environment:
       VIRTUALENV_DIR: "~/virtualenv"
@@ -78,7 +76,6 @@ jobs:
       - run:
           name: Download and Install Dependencies
           command: |
-            git clone -b "${CI_BRANCH:-master}" git://github.com/stackstorm-exchange/ci.git ~/ci
             git clone --depth 1 --single-branch --branch "${LINT_CONFIGS_BRANCH:-master}" https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
             sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv pyyaml
             virtualenv ~/virtualenv
@@ -117,7 +114,6 @@ jobs:
       #     paths:
       #       - home/circleci/ci
       #       - home/circleci/virtualenv
-      #       - home/circleci/repo
       #       - home/circleci/.gitconfig
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: Check Python files
           command: |
-            ~/virtualenv/bin/flake8 --config=~/ci/lint-configs/python/.flake8-exchange
+            ~/virtualenv/bin/flake8 --max-line-length=100 --config=~/ci/lint-configs/python/.flake8-exchange
             find . -name '*.py' | xargs ~/virtualenv/bin/pylint --rcfile=~/ci/lint-configs/python/.pylintrc-pack-ci
       - run:
           name: Check Makefile syntax
@@ -101,7 +101,7 @@ jobs:
       - run:
           name: Check Python files
           command: |
-            ~/virtualenv/bin/flake8 --config=~/ci/lint-configs/python/.flake8-exchange
+            ~/virtualenv/bin/flake8 --max-line-length=100 --config=~/ci/lint-configs/python/.flake8-exchange
             find . -name '*.py' | xargs ~/virtualenv/bin/pylint --rcfile=~/ci/lint-configs/python/.pylintrc-pack-ci
       - run:
           name: Check Makefile syntax

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           name: Check Python files
           command: |
             ~/virtualenv/bin/flake8 --config=~/ci/lint-configs/python/.flake8-exchange
-            find . -name '*.py' | xargs ~/virtualenv/bin/pylint --rcfile=~/ci/lint-configs/python/.pylintrc
+            find . -name '*.py' | xargs ~/virtualenv/bin/pylint --rcfile=~/ci/lint-configs/python/.pylintrc-pack-ci
       - run:
           name: Check Makefile syntax
           command: |
@@ -102,7 +102,7 @@ jobs:
           name: Check Python files
           command: |
             ~/virtualenv/bin/flake8 --config=~/ci/lint-configs/python/.flake8-exchange
-            find . -name '*.py' | xargs ~/virtualenv/bin/pylint --rcfile=~/ci/lint-configs/python/.pylintrc
+            find . -name '*.py' | xargs ~/virtualenv/bin/pylint --rcfile=~/ci/lint-configs/python/.pylintrc-pack-ci
       - run:
           name: Check Makefile syntax
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,12 @@
+# DO NOT COPY THIS CONFIG - this is the CI config for the ci repository itself,
+# IT IS NOT THE CI CONFIG FOR PACKS.
+# The sample pack CI config is .circle/config.yml.sample
 version: 2
 
 jobs:
-  build_and_test:
+  test_py27:
     docker:
       - image: circleci/python:2.7
-      - image: rabbitmq:3
-      - image: mongo:3.4
 
     working_directory: ~/repo
 
@@ -14,33 +15,56 @@ jobs:
 
     steps:
       - checkout
-      - restore_cache:
-          key: v1-dependency-cache-{{ checksum "requirements.txt" }}
+      # - restore_cache:
+      #     key: v1-dependency-cache-{{ checksum "requirements.txt" }}
       - run:
           name: Download and Install Dependencies
           command: |
-            git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
-            ~/ci/.circle/dependencies
+            git clone -b "${CI_BRANCH:-master}" git://github.com/stackstorm-exchange/ci.git ~/ci
+            git clone --depth 1 --single-branch --branch "${LINT_CONFIGS_BRANCH:-master}" https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
+            sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv pyyaml
+            virtualenv ~/virtualenv
+            ~/virtualenv/bin/pip install flake8 pylint pyyaml
       - run:
-          name: Run Lint Checks and Tests
-          command: ~/ci/.circle/test
-      - save_cache:
-          key: v1-dependency-cache-{{ checksum "requirements.txt" }}
-          paths:
-            - ~/.cache/pip
-            - ~/.apt-cache
-      - persist_to_workspace:
-          root: /
-          paths:
-            - home/circleci/ci
-            - home/circleci/virtualenv
-            - tmp/st2
-            - home/circleci/repo
-            - home/circleci/.gitconfig
+          name: Check YAML file syntax
+          command: >
+            find . \( -name '*.yml' \
+                   -o -name '*.yml.sample' \
+                   -o -name '*.yaml' \
+                   -o -name '*.yaml.sample' \) \
+                   -print | \
+            xargs -I "{}" python -c 'import yaml; yaml.safe_load(open("{}").read())'
+      - run:
+          name: Check Bash file syntax
+          command: |
+            find . -name '*.sh' | xargs bash -n
+            grep -lrE '^#!/bin/bash' | xargs bash -n
+            grep -lrE '^#!/usr/bin/env sh' . | xargs sh -n\
+      - run:
+          name: Check Python files
+          command: |
+            ~/virtualenv/bin/flake8 --config=~/ci/lint-configs/python/.flake8-exchange
+            find . -name '*.py' | xargs ~/virtualenv/bin/pylint --rcfile=~/ci/lint-configs/python/.pylintrc
+      - run:
+          name: Check Makefile syntax
+          command: |
+            find . -name Makefile | xargs make -n
+      # - save_cache:
+      #     key: v1-dependency-cache-{{ checksum "requirements.txt" }}
+      #     paths:
+      #       - ~/.cache/pip
+      #       - ~/.apt-cache
+      # - persist_to_workspace:
+      #     root: /
+      #     paths:
+      #       - home/circleci/ci
+      #       - home/circleci/virtualenv
+      #       - home/circleci/repo
+      #       - home/circleci/.gitconfig
 
-  deploy:
+  test_py36:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.6
 
     working_directory: ~/repo
 
@@ -49,25 +73,56 @@ jobs:
 
     steps:
       - checkout
-      - restore_cache:
-          key: v1-dependency-cache-{{ checksum "requirements.txt" }}
-      - attach_workspace:
-          at: /
+      # - restore_cache:
+      #     key: v1-dependency-cache-{{ checksum "requirements.txt" }}
       - run:
-          name: Install dependencies
-          command: sudo apt -y install gmic optipng
+          name: Download and Install Dependencies
+          command: |
+            git clone -b "${CI_BRANCH:-master}" git://github.com/stackstorm-exchange/ci.git ~/ci
+            git clone --depth 1 --single-branch --branch "${LINT_CONFIGS_BRANCH:-master}" https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
+            sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv pyyaml
+            virtualenv ~/virtualenv
+            ~/virtualenv/bin/pip install flake8 pylint pyyaml
       - run:
-          name: Update exchange.stackstorm.org
-          command:  ~/ci/.circle/deployment
+          name: Check YAML file syntax
+          command: >
+            find . \( -name '*.yml' \
+                   -o -name '*.yml.sample' \
+                   -o -name '*.yaml' \
+                   -o -name '*.yaml.sample' \) \
+                   -print | \
+            xargs -I "{}" python -c 'import yaml; yaml.safe_load(open("{}").read())'
+      - run:
+          name: Check Bash file syntax
+          command: |
+            find . -name '*.sh' | xargs bash -n
+            grep -lrE '^#!/bin/bash' | xargs bash -n
+            grep -lrE '^#!/usr/bin/env sh' . | xargs sh -n\
+      - run:
+          name: Check Python files
+          command: |
+            ~/virtualenv/bin/flake8 --config=~/ci/lint-configs/python/.flake8-exchange
+            find . -name '*.py' | xargs ~/virtualenv/bin/pylint --rcfile=~/ci/lint-configs/python/.pylintrc
+      - run:
+          name: Check Makefile syntax
+          command: |
+            find . -name Makefile | xargs make -n
+      # - save_cache:
+      #     key: v1-dependency-cache-{{ checksum "requirements.txt" }}
+      #     paths:
+      #       - ~/.cache/pip
+      #       - ~/.apt-cache
+      # - persist_to_workspace:
+      #     root: /
+      #     paths:
+      #       - home/circleci/ci
+      #       - home/circleci/virtualenv
+      #       - home/circleci/repo
+      #       - home/circleci/.gitconfig
 
 workflows:
   version: 2
   build_test_deploy:
     jobs:
-      - build_and_test
-      - deploy:
-          requires:
-            - build_and_test
-          filters:
-            branches:
-              only: master
+      - test_py27
+      - test_py36

--- a/utils/pack_content.py
+++ b/utils/pack_content.py
@@ -2,13 +2,13 @@
 #
 # A helper script to count content in a pack.
 #
-import os
+import argparse
 import errno
 import glob
 import json
-import yaml
-import argparse
+import os
 from collections import OrderedDict
+import yaml
 
 RESOURCE_LOCATOR = {
     'sensors': {
@@ -46,7 +46,7 @@ RESOURCE_LOCATOR = {
 
 
 def ordered_load(stream, Loader=yaml.SafeLoader, object_pairs_hook=OrderedDict):
-    class OrderedLoader(Loader):
+    class OrderedLoader(Loader):  # pylint: disable=too-many-ancestors
         pass
 
     def construct_mapping(loader, node):
@@ -59,7 +59,7 @@ def ordered_load(stream, Loader=yaml.SafeLoader, object_pairs_hook=OrderedDict):
 
 
 def ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):
-    class OrderedDumper(Dumper):
+    class OrderedDumper(Dumper):  # pylint: disable=too-many-ancestors
         pass
 
     def _dict_representer(dumper, data):
@@ -73,7 +73,7 @@ def ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):
 def get_pack_resources(pack_dir):
     resources = {}
 
-    for resource, locator in RESOURCE_LOCATOR.iteritems():
+    for resource, locator in RESOURCE_LOCATOR.items():
 
         resources[resource] = []
         matching_files = []
@@ -104,8 +104,8 @@ def get_pack_resources(pack_dir):
 
 def return_resource_count(resources):
     result = {}
-    for resource, entities in resources.iteritems():
-        if len(entities):
+    for resource, entities in resources.items():
+        if entities:
             key = RESOURCE_LOCATOR[resource]['key']
             result[resource] = {
                 'resources': sorted([item[key] for item in entities]),
@@ -128,7 +128,7 @@ if __name__ == '__main__':
     content = get_pack_resources(args.input)
     meta['content'] = return_resource_count(content)
 
-    for resource_type, resource_entities in content.iteritems():
+    for resource_type, resource_entities in content.items():
         key = RESOURCE_LOCATOR[resource_type]['key']
         directory = os.path.join(args.output, resource_type)
         try:

--- a/utils/pack_content.py
+++ b/utils/pack_content.py
@@ -11,37 +11,37 @@ import argparse
 from collections import OrderedDict
 
 RESOURCE_LOCATOR = {
-  'sensors': {
-    'path': ['sensors/*.yaml', 'sensors/*.yml'],
-    'key': 'class_name'
-  },
-  'actions': {
-    'path': ['actions/*.yaml', 'actions/*.yml'],
-    'key': 'name'
-  },
-  'rules': {
-    'path': ['rules/*.yaml', 'rules/*.yml'],
-    'key': 'name'
-  },
-  'runners': {
-    'path': ['runners/*/runner.yaml', 'runners/*/runner.yml'],
-    'key': 'name'
-  },
-  'triggers': {
-    'path': ['triggers/*.yaml', 'triggers/*.yml'],
-    'key': 'name'
-  },
-  'aliases': {
-    'path': ['aliases/*.yaml', 'aliases/*.yml'],
-    'key': 'name'
-  },
-  'policies': {
-    'path': ['policies/*.yaml', 'policies/*.yml'],
-    'key': 'name'
-  },
-  'tests': {
-    'key': 'filename'
-  }
+    'sensors': {
+        'path': ['sensors/*.yaml', 'sensors/*.yml'],
+        'key': 'class_name',
+    },
+    'actions': {
+        'path': ['actions/*.yaml', 'actions/*.yml'],
+        'key': 'name',
+    },
+    'rules': {
+        'path': ['rules/*.yaml', 'rules/*.yml'],
+        'key': 'name',
+    },
+    'runners': {
+        'path': ['runners/*/runner.yaml', 'runners/*/runner.yml'],
+        'key': 'name',
+    },
+    'triggers': {
+        'path': ['triggers/*.yaml', 'triggers/*.yml'],
+        'key': 'name',
+    },
+    'aliases': {
+        'path': ['aliases/*.yaml', 'aliases/*.yml'],
+        'key': 'name',
+    },
+    'policies': {
+        'path': ['policies/*.yaml', 'policies/*.yml'],
+        'key': 'name',
+    },
+    'tests': {
+        'key': 'filename',
+    },
 }
 
 

--- a/utils/pack_content.py
+++ b/utils/pack_content.py
@@ -86,8 +86,8 @@ def get_pack_resources(pack_dir):
         for path in locator['path']:
             matching_files += glob.glob(os.path.join(pack_dir, path))
 
-        for file in matching_files:
-            with open(file, 'r') as fp:
+        for f in matching_files:
+            with open(f, 'r') as fp:
                 metadata = fp.read()
             metadata = yaml.safe_load(metadata)
             valid = True

--- a/utils/pack_content.py
+++ b/utils/pack_content.py
@@ -2,6 +2,8 @@
 #
 # A helper script to count content in a pack.
 #
+from __future__ import print_function
+
 import argparse
 import errno
 import glob


### PR DESCRIPTION
Add some quick checks for this `ci` repo.

This is a good idea to begin with, but this is immediately valuable to ensure that all of the Python scripts work on both Python 2.7 and Python 3, because some of our packs use Python 3 to deploy. And that's a trend that will only accelerate as Python 2 usage drops off.