### PR TITLE
Make sure we run unit tests if FORCE_CHECK_ALL_FILES is true

### DIFF
--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -181,10 +181,10 @@ compile:
 	@echo "==================== packs-resource-register ===================="
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; \
-	if [ ${NUM_CHANGED_FILES} -eq 0 ]; then \
-		echo "No files have changed, skipping run..."; \
-	else \
+	if [ "$${FORCE_CHECK_ALL_FILES}" = "true" ] || [ ${NUM_CHANGED_FILES} -gt 0 ]; then \
 		st2-check-register-pack-resources /tmp/packs/$(PACK_NAME) || exit 1; \
+	else \
+		echo "No files have changed, skipping run..."; \
 	fi;
 
 .PHONY: .packs-tests
@@ -204,10 +204,10 @@ compile:
 	@echo
 	@echo "==================== pack-missing-tests ===================="
 	@echo
-	if [ ${NUM_CHANGED_FILES} -eq 0 ]; then \
-		echo "No files have changed, skipping run..."; \
-	else \
+	if [ "$${FORCE_CHECK_ALL_FILES}" = "true" ] || [ ${NUM_CHANGED_FILES} -gt 0 ]; then \
 		st2-check-print-pack-tests-coverage $(ROOT_DIR) || exit 1; \
+	else \
+		echo "No files have changed, skipping run..."; \
 	fi;
 
 # Target which veries repo root contains LICENSE file with ASF 2.0 content

--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -195,10 +195,10 @@ compile:
 	@echo "==================== packs-tests ===================="
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; \
-	if [ ${NUM_CHANGED_FILES} -eq 0 ]; then \
-		echo "No files have changed, skipping run..."; \
-	else \
+	if [ "$${FORCE_CHECK_ALL_FILES}" = "true" ] || [ ${NUM_CHANGED_FILES} -gt 0 ]; then \
 		$(ST2_REPO_PATH)/st2common/bin/st2-run-pack-tests -c -t -x -j -p $(ROOT_DIR) || exit 1; \
+	else \
+		echo "No files have changed, skipping run..."; \
 	fi;
 
 .PHONY: .packs-missing-tests

--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -77,6 +77,7 @@ compile:
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; \
 	if [ "$${FORCE_CHECK_ALL_FILES}" = "true" ]; then \
+		echo "Force flake8 checks on all files"; \
 		find ./* -name "*.py" | while read py_file; do \
 			flake8 --config=$(CI_DIR)/lint-configs/python/.flake8 $$py_file || exit 1; \
 		done; \
@@ -120,6 +121,7 @@ compile:
 	@# iterate through each element of the array
 	. $(VIRTUALENV_DIR)/bin/activate; \
 	if [ "$${FORCE_CHECK_ALL_FILES}" = "true" ]; then \
+		echo "Force checking all YAML files"; \
 		find $(CI_DIR)/* -name "*.yaml" -o -name "*.yml" | while read yaml_file; do \
 			st2-check-validate-yaml-file "$$yaml_file" || exit 1 ; \
 		done; \
@@ -138,6 +140,7 @@ compile:
 	@#
 	. $(VIRTUALENV_DIR)/bin/activate; \
 	if [ "$${FORCE_CHECK_ALL_FILES}" = "true" ]; then \
+		echo "Force checking all JSON files"; \
 		find $(CI_DIR)/* -name "*.json" | while read json_file; do \
 			st2-check-validate-json-file "$$json_file" || exit 1 ; \
 		done; \

--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -78,7 +78,7 @@ compile:
 	. $(VIRTUALENV_DIR)/bin/activate; \
 	if [ "$${FORCE_CHECK_ALL_FILES}" = "true" ]; then \
 		echo "Force flake8 checks on all files"; \
-		find ./* -name "*.py" | while read py_file; do \
+		find $(ROOT_DIR)/* -name "*.py" | while read py_file; do \
 			flake8 --config=$(CI_DIR)/lint-configs/python/.flake8 $$py_file || exit 1; \
 		done; \
 	elif [ ${NUM_CHANGED_PY} -gt 0 ]; then \
@@ -122,7 +122,7 @@ compile:
 	. $(VIRTUALENV_DIR)/bin/activate; \
 	if [ "$${FORCE_CHECK_ALL_FILES}" = "true" ]; then \
 		echo "Force checking all YAML files"; \
-		find $(CI_DIR)/* -name "*.yaml" -o -name "*.yml" | while read yaml_file; do \
+		find $(ROOT_DIR)/* -name "*.yaml" -o -name "*.yml" | while read yaml_file; do \
 			st2-check-validate-yaml-file "$$yaml_file" || exit 1 ; \
 		done; \
 	elif [ ${NUM_CHANGED_YAML} -gt 0 ]; then \
@@ -141,7 +141,7 @@ compile:
 	. $(VIRTUALENV_DIR)/bin/activate; \
 	if [ "$${FORCE_CHECK_ALL_FILES}" = "true" ]; then \
 		echo "Force checking all JSON files"; \
-		find $(CI_DIR)/* -name "*.json" | while read json_file; do \
+		find $(ROOT_DIR)/* -name "*.json" | while read json_file; do \
 			st2-check-validate-json-file "$$json_file" || exit 1 ; \
 		done; \
 	elif [ -n "${NUM_CHANGED_JSON}" ]; then \

--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -1,10 +1,8 @@
 ROOT_DIR ?= $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-ifndef FORCE_CHECK_ALL_FILES
 NUM_CHANGED_FILES := $(shell $(CI_DIR)/utils/git-changes files | wc -w)
 NUM_CHANGED_PY := $(shell $(CI_DIR)/utils/git-changes py | wc -w)
 NUM_CHANGED_YAML := $(shell $(CI_DIR)/utils/git-changes yaml | wc -w)
 NUM_CHANGED_JSON := $(shell $(CI_DIR)/utils/git-changes json | wc -w)
-endif
 CHANGED_DIRECTORIES := $(shell $(CI_DIR)/utils/git-changes directories)
 VIRTUALENV_DIR ?= virtualenv
 ST2_REPO_PATH ?= /tmp/st2

--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -67,6 +67,8 @@ compile:
 	@echo "======================= compile ========================"
 	@echo "------- Compile all .py files (syntax check test) ------"
 	if python -c 'import compileall,re; compileall.compile_dir(".", rx=re.compile(r"/virtualenv|virtualenv-osx|virtualenv-py3|.tox|.git|.venv-st2devbox"), quiet=True)' | grep .; then exit 1; else exit 0; fi
+	@echo
+	@echo "All files compiled successfully"
 
 .PHONY: .flake8
 .flake8:
@@ -226,7 +228,9 @@ compile:
 		cat $(ROOT_DIR)/LICENSE | grep -q "Apache License"  || (echo "LICENSE file doesn't contain Apache 2.0 license text" ; exit 2); \
 		cat $(ROOT_DIR)/LICENSE | grep -q "Version 2.0"  || (echo "LICENSE file doesn't contain Apache 2.0 license text" ; exit 2); \
 		cat $(ROOT_DIR)/LICENSE | grep -q "www.apache.org/licenses/LICENSE-2.0"  || (echo "LICENSE file doesn't contain Apache 2.0 license text" ; exit 2); \
-	fi;
+	fi
+	@echo
+	@echo "License looks good"
 
 .PHONY: .clone_st2_repo
 .clone_st2_repo: /tmp/st2

--- a/.circle/test
+++ b/.circle/test
@@ -34,6 +34,7 @@ if [[ "${GIT_BRANCH}" = "master" ]]; then
 fi
 
 if [[ -n "${FORCE_CHECK_ALL_FILES}" ]]; then
+    echo "FORCE_CHECK_ALL_FILES is non-empty: ${FORCE_CHECK_ALL_FILES}"
     export FORCE_CHECK_ALL_FILES="${FORCE_CHECK_ALL_FILES}"
 fi
 


### PR DESCRIPTION
My PR here (https://github.com/StackStorm-Exchange/stackstorm-circle_ci/pull/8#issuecomment-614640449) seems to have uncovered a bug with unit tests not being ran when ``FORCE_CHECK_ALL_FILES`` is set (e.g. for master builds or weekly builds).

I have no idea how long has this been broken / not working correctly (could have been since the beginning).

This being broken basically means we didn't run any pack unit tests as part of our weekly builds (that's obviously bad and it means we likely missed a bunch of failures).