### PR TITLE
Check for the MIT license for the napalm_logs and netbox packs

### DIFF
--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -216,24 +216,36 @@ compile:
 	fi;
 
 # Target which veries repo root contains LICENSE file with ASF 2.0 content
+# We allow the napalm_logs and netbox packs to have MIT licenses, since they
+# adopted those licenses before this check was put in place, so they are
+# effectively grandfathered in
+# However, all other packs, including any new packs, are required to be
+# licensed under the Apache 2.0 License
 .PHONY: .license-check
 .license-check:
 	@echo
 	@echo "==================== license-check ===================="
 	@echo
-	if [ ${NUM_CHANGED_FILES} -eq 0 ] && [ "$${FORCE_CHECK_ALL_FILES}" = "false" ]; then \
+	@if [ ${NUM_CHANGED_FILES} -eq 0 ] && [ "$${FORCE_CHECK_ALL_FILES}" = "false" ]; then \
 		echo "No files have changed, skipping run..."; \
 	else \
 		if [ ! -f "$(ROOT_DIR)/LICENSE" ]; then \
 			echo "Missing LICENSE file in $(ROOT_DIR)"; \
 			exit 2;\
 		fi;\
-		cat $(ROOT_DIR)/LICENSE | grep -q "Apache License"  || (echo "LICENSE file doesn't contain Apache 2.0 license text" ; exit 2); \
-		cat $(ROOT_DIR)/LICENSE | grep -q "Version 2.0"  || (echo "LICENSE file doesn't contain Apache 2.0 license text" ; exit 2); \
-		cat $(ROOT_DIR)/LICENSE | grep -q "www.apache.org/licenses/LICENSE-2.0"  || (echo "LICENSE file doesn't contain Apache 2.0 license text" ; exit 2); \
+		if [ "$$(python -c 'import yaml; f = open("/home/circleci/repo/pack.yaml"); print(yaml.safe_load(f.read())["name"]); f.close();')" = "napalm_logs" ] || \
+		   [ "$$(python -c 'import yaml; f = open("/home/circleci/repo/pack.yaml"); print(yaml.safe_load(f.read())["name"]); f.close();')" = "netbox" ]; then \
+			cat $(ROOT_DIR)/LICENSE | grep -q "MIT License"  || (echo "LICENSE file doesn't contain MIT license text" ; exit 2); \
+			cat $(ROOT_DIR)/LICENSE | grep -q "Copyright (c) 2017 John Anderson"  || (echo "LICENSE file doesn't include John Anderson's name" ; exit 2); \
+			cat $(ROOT_DIR)/LICENSE | grep -q "Permission is hereby granted, free of charge, to any person obtaining a copy"  || (echo "LICENSE file doesn't contain MIT license text" ; exit 2); \
+			echo "Pack is licensed under the MIT License -- :)"; \
+		else \
+			cat $(ROOT_DIR)/LICENSE | grep -q "Apache License"  || (echo "LICENSE file doesn't contain Apache 2.0 license text" ; exit 2); \
+			cat $(ROOT_DIR)/LICENSE | grep -q "Version 2.0"  || (echo "LICENSE file doesn't contain Apache 2.0 license text" ; exit 2); \
+			cat $(ROOT_DIR)/LICENSE | grep -q "www.apache.org/licenses/LICENSE-2.0"  || (echo "LICENSE file doesn't contain Apache 2.0 license text" ; exit 2); \
+			echo "Pack is licensed under the Apache 2.0 License -- :)"; \
+		fi; \
 	fi
-	@echo
-	@echo "License looks good"
 
 .PHONY: .clone_st2_repo
 .clone_st2_repo: /tmp/st2


### PR DESCRIPTION
Unfortunately the napalm_logs and netbox packs are not licensed under the Apache 2.0 License like the rest of the packs are.

I initiated [a PR](https://github.com/StackStorm-Exchange/stackstorm-netbox/pulls/17) to change the license, but we cannot do so without the consent of every contributor to those packs, and at this point I don't think we are going to get that from all contributors. Same story with the napalm_logs pack.

So, instead of checking for the Apache 2.0 license on those packs and failing every weekly CI run, we simply hardcode those two packs to exempt them from the Apache 2.0 License requirement. Luckily both are licensed under the very liberal MIT license, and were initially authored by John Anderson, so for those two packs we check for the MIT license instead.

I manually tested this with both packs, and the AWS pack to ensure it doesn't break anything.

Since the Bash commands to actually run the checks are getting very complex, and because the error messages for all of the checks are very well written and make it very clear how to fix the issue, I muted them from being printed before execution with the `@`.

In my opinion, the ancient Unix philosophy of "be quiet unless you can't do your job" does not apply to tests, where you want to verify that the tests either successfully ran or successfully failed. Therefore, I have each branch each print out different success message indicating the detected license along with a smiley face, and I tweaked the error message if the MIT license is not found.

Fixes:
* https://circleci.com/gh/StackStorm-Exchange/stackstorm-napalm_logs/166
* https://circleci.com/gh/StackStorm-Exchange/stackstorm-netbox/254
* https://circleci.com/gh/StackStorm-Exchange/stackstorm-netbox/255