### PR TITLE
Fix pylint by locking isort module below version 5

### DIFF
--- a/.circle/requirements-dev.txt
+++ b/.circle/requirements-dev.txt
@@ -5,3 +5,5 @@ pep8>=1.6.0,<1.7
 flake8==3.7.7
 astroid==1.6.5
 pylint==1.9.4
+# fix isort dependency of pylint 1.9.4 by keeping it below its 5.x version
+isort>=4.2.5,<5


### PR DESCRIPTION
With the new release of isort 5 that gets installed as a dependency of pylint, the pylint CI step is currently broken with the following error:
```
AttributeError: module 'isort' has no attribute 'SortImports'
```
This dependency issue is only fixed in newer pylint versions (>=2.4)