### PR TITLE
Improve deployment scripts

### DIFF
--- a/tools/reset_github_user_token_and_update_circleci.sh
+++ b/tools/reset_github_user_token_and_update_circleci.sh
@@ -20,7 +20,13 @@ fi
 PACK="$1"
 EXCHANGE_ORG="${EXCHANGE_ORG:-StackStorm-Exchange}"
 EXCHANGE_PREFIX="${EXCHANGE_PREFIX:-stackstorm}"
-REPO_NAME="${EXCHANGE_PREFIX}-${PACK}"
+# Add the stackstorm- prefix to the repo name if it doesn't exist already
+if [[ "$PACK" = ${EXCHANGE_PREFIX}-* ]];
+then
+    REPO_NAME="$PACK"
+else
+    REPO_NAME="${EXCHANGE_PREFIX}-${PACK}"
+fi
 
 DEFAULT_USERNAME="stackstorm-neptr"
 if [[ -z "$USERNAME" ]];

--- a/tools/reset_github_user_token_and_update_circleci.sh
+++ b/tools/reset_github_user_token_and_update_circleci.sh
@@ -22,6 +22,31 @@ EXCHANGE_ORG="${EXCHANGE_ORG:-StackStorm-Exchange}"
 EXCHANGE_PREFIX="${EXCHANGE_PREFIX:-stackstorm}"
 REPO_NAME="${EXCHANGE_PREFIX}-${PACK}"
 
+DEFAULT_USERNAME="stackstorm-neptr"
+if [[ -z "$USERNAME" ]];
+then
+    echo "What is the username for the GitHub user?"
+    echo "Default: $DEFAULT_USERNAME (just hit enter to use this)"
+    read USERNAME
+    USERNAME="${USERNAME:-$DEFAULT_USERNAME}"
+fi
+
+if [[ -z "$PASSWORD" ]];
+then
+    echo "What is the password for the GitHub user (${USERNAME})?"
+    echo "This password is stored in LastPass under the ${DEFAULT_USERNAME}"
+    echo "account."
+    read -s PASSWORD
+fi
+
+if [[ -z "$CIRCLECI_TOKEN" ]];
+then
+    echo "What is the CircleCI token for the ${EXCHANGE_ORG}?"
+    echo "This token is stored in LastPass in the notes section under the "
+    echo "${DEFAULT_USERNAME} for GitHub."
+    read -s CIRCLECI_TOKEN
+fi
+
 # GitHub: create a user-scope token
 # TODO: Delete any existing token for that repo
 echo "Github: Creating a Github user-scoped token"


### PR DESCRIPTION
When packs on Exchange fail to deploy, we don't have any good ways of detecting that failure and exiting gracefully with an informative or useful error message. On top of that, we don't point TSC members to the PAT tools in this `ci` repo, nor do we mention that the required credentials are in LastPass. And then on top of that, the reset token script tries to silently read environment variables.

This PR improves this entire situation, by "closing the loop" and laying down a trail of breadcrumbs for uninitiated users, both community members and TSC members.

First, it asks the user for the GitHub username and password, and then asks for the CircleCI token. If any of those are specified in environment variables, it silently uses those and skips asking the user for them. When the script asks for the values, it notes where those values can be found (eg: the specific accounts and fields in LastPass) to hopefully help the user determine whether or not they have access to the required GitHub and CircleCI credentials.

Second, it isn't clear that the pack name should be specified _without_ the exchange prefix (`stackstorm`, as in `stackstorm-vault`). Instead of throwing an error, the script now skips adding the prefix itself if the name already has it.

Next, instead of writing the GitHub PAT to a temporary file and reading it in again, the script now just echoes the returned PAT to a variable and interpolates that variable when setting it in CircleCI.

Finally, the index generating script now counts how many repositories it cannot clone and process, points the user to the reset tool in `StackStorm-Exchange/ci`, and mentions that a TSC member with the appropriate permissions may need to run the reset tool.