### PR TITLE
Fix CI build missing new LDAP package dependency

### DIFF
--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -30,6 +30,8 @@ sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/ar
 # We use work-around from https://discuss.circleci.com/t/error-installing-imagemagick/2963
 sudo apt-get update
 sudo apt-get -y install python-dev jq gmic optipng
+# Installing dependencies for st2 pip build
+sudo apt-get -y install libldap2-dev libsasl2-dev
 
 sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv
 


### PR DESCRIPTION
Fixes the following build error in StackStorm-Exchange during the pip install st2/requirements.txt
```
    Modules/constants.h:7:10: fatal error: lber.h: No such file or directory
     #include "lber.h"
              ^~~~~~~~
    compilation terminated.
    error: command 'gcc' failed with exit status 1
    ----------------------------------------
```

Example failure: https://app.circleci.com/pipelines/github/StackStorm-Exchange/stackstorm-jmx/39/workflows/4c5d22d5-64a5-4ab8-9c31-0e97f620813a/jobs/247