### PR TITLE
Use bash [[ builtin to test for nonempty variable

### DIFF
--- a/.circle/test
+++ b/.circle/test
@@ -39,7 +39,7 @@ if [[ -n "${FORCE_CHECK_ALL_FILES}" ]]; then
 fi
 
 # We want to use special config file for tests which sets pack base path to /tmp/packs/
-if "${COMMON_LIBS}"; then
+if [[ -n "${COMMON_LIBS}" ]]; then
   echo "Common libs PATH selected"
   export ST2_CONFIG_FILE=${CI_DIR}/conf/st2_common_libs.tests.conf
 else


### PR DESCRIPTION
A previous commit tried to use an empty string in a Bash `if` statement, but Bash doesn't work that way.

This PR tweaks that line to use Bash's `[[` builtin test function in the `if` statement.

This should help us avoid error messages like:

```
/home/circleci/ci/.circle/test: line 42: : command not found
```

in pack CI tests.

The tests still complete just fine, but that error could be a red herring for people investigating pack CI failures.