### PR TITLE
Custom pack deps script

### DIFF
--- a/.circle/circle.yml.sample
+++ b/.circle/circle.yml.sample
@@ -1,3 +1,14 @@
+# WARNING: Minimize edits to this file!
+#
+# This file is part of the CI infrastructure for the StackStorm-Exchange.
+# As such, it gets overwritten periodically in CI infrastructure updates.
+# Check out `tests/setup_testing_env.sh` for how to customize the test env.
+# If you need to add jobs, docker images, or other changes that do not work
+# in `tests/setup_testing_env.sh`, then please add what you need and avoid
+# changing the standard build_and_test and deploy jobs.
+#
+# Thanks for your contribution!
+---
 version: 2
 
 jobs:

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -48,6 +48,7 @@ echo "Installing StackStorm runners and registering metrics drivers"
 if [[ -n "${ROOT_DIR}" ]]; then
     PACK_REQUIREMENTS_FILE="${ROOT_DIR}/requirements.txt"
     PACK_TESTS_REQUIREMENTS_FILE="${ROOT_DIR}/requirements-tests.txt"
+    PACK_SETUP_TESTING_ENV="${ROOT_DIR}/tests/setup_testing_env.sh"
 
     echo "Copying Makefile to ${ROOT_DIR}"
     cp ~/ci/.circle/Makefile ${ROOT_DIR}
@@ -55,6 +56,7 @@ if [[ -n "${ROOT_DIR}" ]]; then
 else
     PACK_REQUIREMENTS_FILE="$(pwd)/requirements.txt"
     PACK_TESTS_REQUIREMENTS_FILE="$(pwd)/requirements-tests.txt"
+    PACK_SETUP_TESTING_ENV="$(pwd)/tests/setup_testing_env.sh"
 
     echo "Copying Makefile to $(pwd)"
     cp ~/ci/.circle/Makefile .
@@ -71,6 +73,12 @@ fi
 if [[ -f "${PACK_TESTS_REQUIREMENTS_FILE}" ]]; then
     echo "Installing pack tests requirements from ${PACK_TESTS_REQUIREMENTS_FILE}"
     ~/virtualenv/bin/pip install -r "${PACK_TESTS_REQUIREMENTS_FILE}"
+fi
+
+# Install custom pack testing enviornment
+if [[ -x "${PACK_SETUP_TESTING_ENV}" ]]; then
+    echo "Setting up custom pack testing environment with ${PACK_SETUP_TESTING_ENV}"
+    "${PACK_SETUP_TESTING_ENV}"
 fi
 
 echo "Installed dependencies:"

--- a/.circle/setup_testing_env.sh.sample
+++ b/.circle/setup_testing_env.sh.sample
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# For python deps, please use requirements.txt or requirements-test.txt.
+# Do not install python requirements with this script.
+
+# Some packs need to install and configure additional packages to properly
+# run their test suite. Other packs need to clone other repositories to
+# reuse standardized testing infrastructure. And other functional or end-to-end
+# tests might need additional system setup to access external APIs via
+# an enterprise bus or something else.
+# That is the purpose of this script. Setup the testing environment
+# to do mock-less regression or end-to-end testing.
+
+# This script is called by `deployment` housed in StackStorm-exchange/ci.
+# `deployment` will only run this script if it is executable.

--- a/utils/exchange-bootstrap.sh
+++ b/utils/exchange-bootstrap.sh
@@ -101,6 +101,11 @@ git add .circleci/config.yml
 curl -sS --fail "https://raw.githubusercontent.com/StackStorm-Exchange/ci/master/files/.gitignore.sample" > .gitignore
 git add .gitignore
 
+mkdir tests
+curl -sS --fail "https://raw.githubusercontent.com/StackStorm-Exchange/ci/master/.circle/setup_testing_env.sh.sample" > tests/setup_testing_env.sh
+# no execute bit until pack-author enables it.
+git add tests/setup_testing_env.sh
+
 git commit -m "Bootstrap a StackStorm Exchange pack repository for pack ${PACK}."
 git push origin master
 


### PR DESCRIPTION
I need some additional setup to run tests in the StackStorm-Exchange/stackstorm-vault#19.

This adds running the custom testing env setup script to the `dependencies` script.
It also adds a sample (empty) script and bootstraps new packs with it.