### PR TITLE
[BUGFIX] Pin the same pip version as core st2

### DIFF
--- a/.circle/Makefile
+++ b/.circle/Makefile
@@ -283,7 +283,7 @@ requirements: virtualenv .clone_st2_repo .install-runners
 	@echo
 	@echo "==================== requirements ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=9.0,<9.1"
+	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==20.0.2"
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache -q -r $(CI_DIR)/.circle/requirements-dev.txt
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache -q -r $(CI_DIR)/.circle/requirements-pack-tests.txt
 
@@ -292,7 +292,7 @@ requirements-ci:
 	@echo
 	@echo "==================== requirements-ci ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=9.0,<9.1"
+	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==20.0.2"
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache -q -r $(CI_DIR)/.circle/requirements-dev.txt
 	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache -q -r $(CI_DIR)/.circle/requirements-pack-tests.txt
 

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -38,10 +38,16 @@ sudo apt-get -y install libldap2-dev libsasl2-dev
 # Hit github's API to keep the PAT active (without failing if it's not)
 (GH_TOKEN=${MACHINE_PASSWORD} gh repo view | head -n2) || true
 
-sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv
+# This should track the pinned version of pip in st2's Makefile
+PIP_DEP="pip==20.0.2"
+sudo pip install -U "${PIP_DEP}" setuptools virtualenv
 
 virtualenv ~/virtualenv
 source ~/virtualenv/bin/activate
+
+# virtualenv is updating pip. Revert back to our pinned version.
+pip install -U "${PIP_DEP}"
+pip --version
 
 # Install StackStorm requirements
 echo "Installing StackStorm requirements from /tmp/st2/requirements.txt"

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -39,15 +39,12 @@ sudo apt-get -y install libldap2-dev libsasl2-dev
 (GH_TOKEN=${MACHINE_PASSWORD} gh repo view | head -n2) || true
 
 # This should track the pinned version of pip in st2's Makefile
-PIP_DEP="pip==20.0.2"
-sudo pip install -U "${PIP_DEP}" setuptools virtualenv
+# Also, make sure virtualenv is built with same pip version below.
+PIP_VERSION="20.0.2"
 
-virtualenv ~/virtualenv
+sudo pip install -U "pip==${PIP_VERSION}" setuptools virtualenv
+virtualenv --pip "${PIP_VERSION}" ~/virtualenv
 source ~/virtualenv/bin/activate
-
-# virtualenv is updating pip. Revert back to our pinned version.
-pip install -U "${PIP_DEP}"
-pip --version
 
 # Install StackStorm requirements
 echo "Installing StackStorm requirements from /tmp/st2/requirements.txt"

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -39,7 +39,7 @@ sudo apt-get -y install libldap2-dev libsasl2-dev
 (GH_TOKEN=${MACHINE_PASSWORD} gh repo view | head -n2) || true
 
 # This should track the pinned version of pip in st2's Makefile
-# Also, make sure virtualenv is built with same pip version below.
+# Please sync this version with .circle/Makefile and .circleci/config.yml
 PIP_VERSION="20.0.2"
 
 sudo pip install -U "pip==${PIP_VERSION}" setuptools virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Download and Install Dependencies
           command: |
             git clone --depth 1 --single-branch --branch "${LINT_CONFIGS_BRANCH:-master}" https://github.com/StackStorm/lint-configs.git ~/ci/lint-configs
-            sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv pyyaml
+            sudo pip install -U "pip==20.0.2" setuptools virtualenv pyyaml
             virtualenv ~/virtualenv
             ~/virtualenv/bin/pip install flake8 pylint pyyaml requests
       - save_cache:


### PR DESCRIPTION
The pack CI is currently pinning `pip>=9.0,<9.1` in the `Makefile` and the `dependencies` script, both of which are used for pack CI (it is also pinned in the circleci config for this repo).

But, core st2 has `pip==20.0.2` pinned in its [`Makefile`](https://github.com/StackStorm/st2/blob/v3.3/Makefile#L56), which is also used by the `dependencies` script for pack CI.
```Makefile
# Pin common pip version here across all the targets
# Note! Periodic maintenance pip upgrades are required to be up-to-date with the latest pip security fixes and updates
PIP_VERSION ?= 20.0.2
```

And, to make the pinned versions even more problematic, `virtualenv` is now installing an even newer version of `pip` just before we try to install the st2 requirements, and that newer pip version (20.3) uses the new pip resolver which can't handle st2 requirements. This is the output of `virtualenv` in [a recent test run]( https://app.circleci.com/pipelines/github/StackStorm-Exchange/stackstorm-vault/72/workflows/262498cc-42ac-474f-8726-5d8b1a7c44b9/jobs/342). Note how pip-9.0.3 gets installed and then virtualenv promptly installs pip-20.3.3.
```
Successfully installed distlib-0.3.1 pip-9.0.3 setuptools-44.1.1 virtualenv-20.4.0
created virtual environment CPython2.7.18.final.0-64 in 512ms
  creator CPython2Posix(dest=/home/circleci/virtualenv, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, wheel=bundle, setuptools=bundle, via=copy, app_data_dir=/home/circleci/.local/share/virtualenv)
    added seed packages: pip==20.3.3, setuptools==44.1.1, wheel==0.36.2
  activators PythonActivator,CShellActivator,FishActivator,PowerShellActivator,BashActivator
Installing StackStorm requirements from /tmp/st2/requirements.txt
```

So, the CI is flapping back and forth between pip-9.0*, pip-20.0*, and pip-20.3* which makes it very difficult to debug.

This PR fixes all that by using the same pinned version of pip that st2 has pinned. It also makes sure the correct version of pip is installed after the virtualenv is built but before the st2 requirements get installed.