### PR TITLE
Use Github graphql api to avoid rate limiting

### DIFF
--- a/.circle/circle.yml.sample
+++ b/.circle/circle.yml.sample
@@ -110,6 +110,7 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt -y install gmic optipng
+            ~/ci/.circle/install_gh
       - run:
           # NOTE: We try to retry the script up to 5 times if it fails. The command could fail due
           # to the race (e.g. we try to push changes to index, but index has been updated by some

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 CURRENT_DIR="$(dirname "$0")"
 

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -34,7 +34,11 @@ sudo apt-get -y install python-dev jq gmic optipng
 sudo apt-get -y install libldap2-dev libsasl2-dev
 
 # make `gh` available for index regeneration
-sudo apt-get -y install https://github.com/cli/cli/releases/download/v1.5.0/gh_1.5.0_linux_amd64.deb
+GH_VERSION="1.5.0"
+[[ -f ~/.apt-cache/gh_${GH_VERSION}_linux_amd64.deb ]] || \
+  curl -L -sS --fail -o ~/.apt-cache/gh_${GH_VERSION}_linux_amd64.deb \
+  "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.deb"
+sudo dpkg -i ~/.apt-cache/gh_${GH_VERSION}_linux_amd64.deb
 
 sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv
 

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -33,12 +33,8 @@ sudo apt-get -y install python-dev jq gmic optipng
 # Installing dependencies for st2 pip build
 sudo apt-get -y install libldap2-dev libsasl2-dev
 
-# make `gh` available for index regeneration
-GH_VERSION="1.5.0"
-[[ -f ~/.apt-cache/gh_${GH_VERSION}_linux_amd64.deb ]] || \
-  curl -L -sS --fail -o ~/.apt-cache/gh_${GH_VERSION}_linux_amd64.deb \
-  "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.deb"
-sudo dpkg -i ~/.apt-cache/gh_${GH_VERSION}_linux_amd64.deb
+# make `gh` available for github API calls
+~/ci/.circle/install_gh
 
 sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv
 

--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -33,6 +33,9 @@ sudo apt-get -y install python-dev jq gmic optipng
 # Installing dependencies for st2 pip build
 sudo apt-get -y install libldap2-dev libsasl2-dev
 
+# make `gh` available for index regeneration
+sudo apt-get -y install https://github.com/cli/cli/releases/download/v1.5.0/gh_1.5.0_linux_amd64.deb
+
 sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv
 
 virtualenv ~/virtualenv

--- a/.circle/deployment
+++ b/.circle/deployment
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 FORCE_REBUILD_INDEX="${FORCE_REBUILD_INDEX:-0}"
 

--- a/.circle/deployment
+++ b/.circle/deployment
@@ -18,8 +18,8 @@ then
   exit 1
 fi
 
-# make `gh` available for github API calls
-~/ci/.circle/install_gh
+# TODO: remove the install_gh call once circleci config is updated in all packs
+type gh &>/dev/null || ~/ci/.circle/install_gh
 
 # TODO: figure out how to make deploy.py rebuild the index.
 # python ~/packs/.circle/deploy.py pack.yaml "${CIRCLE_PROJECT_REPONAME}"

--- a/.circle/deployment
+++ b/.circle/deployment
@@ -23,7 +23,7 @@ fi
 
 # Clean up so the script can be retried in case of failure (e.g. race)
 rm -rf ~/index
-git clone https://${MACHINE_USER}:${MACHINE_PASSWORD}@github.com/StackStorm-Exchange/index ~/index 2>/dev/null
+git clone -q -- "https://${MACHINE_USER}:${MACHINE_PASSWORD}@github.com/StackStorm-Exchange/index" ~/index
 
 echo "Processing pack ${PACK_NAME}"
 
@@ -33,7 +33,7 @@ echo "Processing pack ${PACK_NAME}"
 METADATA_CHANGES=$(git rev-list --all --no-abbrev --remove-empty -- pack.yaml)
 for COMMIT in $(echo $METADATA_CHANGES)
 do
-  git checkout ${COMMIT} pack.yaml > /dev/null
+  git checkout -q ${COMMIT} pack.yaml
   VERSION=$(~/virtualenv/bin/python ~/ci/.circle/semver.py pack.yaml 2>/dev/null || true)
 
   # 1. Create a tag if version is specified and tag doesn't exist locally
@@ -93,7 +93,7 @@ if ! git -C ~/index diff --quiet --exit-code --cached
 then
   echo "Updating the index repo..."
   git -C ~/index commit -m "Update the ${PACK_NAME} pack."
-  git -C ~/index push origin 2>/dev/null
+  git -C ~/index push -q origin
   echo "Index updated."
 
   # echo "Updating the repo description..."

--- a/.circle/deployment
+++ b/.circle/deployment
@@ -18,6 +18,9 @@ then
   exit 1
 fi
 
+# make `gh` available for github API calls
+~/ci/.circle/install_gh
+
 # TODO: figure out how to make deploy.py rebuild the index.
 # python ~/packs/.circle/deploy.py pack.yaml "${CIRCLE_PROJECT_REPONAME}"
 

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -5,6 +5,7 @@ import argparse
 import hashlib
 import json
 import os
+import subprocess
 import time
 from collections import OrderedDict
 from glob import glob
@@ -19,11 +20,28 @@ EXCHANGE_NAME = "StackStorm-Exchange"
 EXCHANGE_PREFIX = "stackstorm"
 
 GITHUB_USERNAME = os.environ.get('MACHINE_USER')
-GITHUB_PASSWORD = os.environ.get('MACHINE_PASSWORD')
+GITHUB_PASSWORD = os.environ.get("MACHINE_PASSWORD", os.environ.get("GH_TOKEN"))
 
 SESSION = requests.Session()
 SESSION.auth = (GITHUB_USERNAME, GITHUB_PASSWORD)
 
+PACK_VERSIONS = {}
+
+GQL_PACK_TAGS_QUERY = """
+query ($owner: String!, $per_page: Int = 100, $endCursor: String) {
+  repositoryOwner(login: $owner) {
+    repositories(first: $per_page, after: $endCursor, ownerAffiliations: OWNER) {
+      nodes {
+        name
+        refs(refPrefix: "refs/tags/", last: 100) {
+          nodes { name }
+        }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}
+"""
 
 def build_index(path_glob, output_path):
     result = OrderedDict({
@@ -105,27 +123,87 @@ def build_index(path_glob, output_path):
     print('Index data written to "%s".' % (output_path))
 
 
+def get_available_versions():
+    """
+    Retrieve all the available versions for all packs
+
+    NOTE: This function uses Github API.
+    """
+    pages = []
+
+    # use `gh` to handle getting all pages
+    proc = subprocess.Popen(
+        [
+            "gh", "api", "--paginate", "graphql",
+            "-f", "owner=" + EXCHANGE_NAME,
+            "-f", "query=" + GQL_PACK_TAGS_QUERY,
+        ],
+        env={"GH_TOKEN": GITHUB_PASSWORD},
+        stdout=subprocess.PIPE,
+    )
+    # This should never take more than 5 seconds.
+    # If network is really bad, let it go for 30.
+    try:
+        outs, _ = proc.communicate(timeout=30)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        outs, _ = proc.communicate()
+    result = outs.decode().strip()
+
+    # https://stackoverflow.com/a/43807246/1134951
+    decoder = json.JSONDecoder()
+    pos = 0
+    len_result = len(result)
+    while pos < len_result:
+        j, json_len = decoder.raw_decode(result, idx=pos)
+        pos += json_len
+        pages.append(j)
+
+    # PREFIX-<pack name>
+    prefix_len = len(EXCHANGE_PREFIX) + 1
+
+    for page in pages:
+        repos = page["data"]["repositoryOwner"]["repositories"]["nodes"]
+        packs = [
+            {
+                "reponame": repo["name"],
+                "tags": [tag["name"] for tag in repo["refs"]["nodes"]]
+            } for repo in repos if repo["name"].startswith(EXCHANGE_PREFIX)
+        ]
+        for pack in packs:
+            pack_name = pack["reponame"][prefix_len:]
+            if pack_name not in PACK_VERSIONS:
+                PACK_VERSIONS[pack_name] = []
+            PACK_VERSIONS[pack_name].extend(
+                tag.replace("v", "") for tag in pack["tags"]
+                if tag.startswith("v")  # only version tags
+            )
+
+
 def get_available_versions_for_pack(pack_ref):
     """
     Retrieve all the available versions for a particular pack.
 
     NOTE: This function uses Github API.
     """
-    url = ('https://api.github.com/repos/%s/%s-%s/tags' %
-           (EXCHANGE_NAME, EXCHANGE_PREFIX, pack_ref))
-    resp = SESSION.get(url)
+    if pack_ref not in PACK_VERSIONS:
+        url = ('https://api.github.com/repos/%s/%s-%s/tags' %
+               (EXCHANGE_NAME, EXCHANGE_PREFIX, pack_ref))
+        resp = SESSION.get(url)
 
-    if resp.status_code != 200:
-        print('Got non 200 response: %s' % (resp.text))
-        return None
+        if resp.status_code != 200:
+            print('Got non 200 response: %s' % (resp.text))
+            return None
 
-    versions = []
+        versions = []
 
-    for item in resp.json():
-        if item.get('name', '').startswith('v'):
-            versions.append(item['name'].replace('v', ''))
+        for item in resp.json():
+            if item.get('name', '').startswith('v'):
+                versions.append(item['name'].replace('v', ''))
+    else:
+        versions = PACK_VERSIONS[pack_ref]
 
-    versions = list(reversed(sorted(versions)))
+    versions = list(reversed(sorted(set(versions))))
 
     return versions
 
@@ -138,4 +216,5 @@ if __name__ == '__main__':
                         required=True)
     args = parser.parse_args()
 
+    get_available_versions()
     build_index(path_glob=args.glob, output_path=args.output)

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -172,9 +172,7 @@ def get_available_versions():
         ]
         for pack in packs:
             pack_name = pack["reponame"][prefix_len:]
-            if pack_name not in PACK_VERSIONS:
-                PACK_VERSIONS[pack_name] = []
-            PACK_VERSIONS[pack_name].extend(
+            PACK_VERSIONS.setdefault(pack_name, []).extend(
                 tag.replace("v", "") for tag in pack["tags"]
                 if tag.startswith("v")  # only version tags
             )

--- a/.circle/install_gh
+++ b/.circle/install_gh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# make `gh` available for index regeneration
+GH_VERSION="${GH_VERSION:-1.5.0}"
+[[ -f ~/.apt-cache/gh_${GH_VERSION}_linux_amd64.deb ]] || \
+  curl -L -sS --fail -o ~/.apt-cache/gh_${GH_VERSION}_linux_amd64.deb \
+  "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.deb"
+sudo dpkg -i ~/.apt-cache/gh_${GH_VERSION}_linux_amd64.deb

--- a/.circle/install_gh
+++ b/.circle/install_gh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # make `gh` available for index regeneration
 GH_VERSION="${GH_VERSION:-1.5.0}"


### PR DESCRIPTION
This adjusts the index regeneration so that it retrieves the list of all
pack versions (repo tags) in as few API calls as possible.

At 1 call per pack per pack deployment, multiple pack deployments can
easily hit the rate limit. Using graphql reduces the number of calls
that count toward the rate limit (today) to 2 per pack deployment.
Tags are apparently a very inexpensive API request, so github is only
counting 1 call per page. More complex queries can count as more than
one call per page, so this is very fortunate for our use case.

Graphql limits each page to 100 results, so with about 160 packs, that
is only 2 pages. So, we won't hit a 3rd page until we get over 200
packs.