### PR TITLE
Use PATs weekly to prevent expiration

### DIFF
--- a/.circle/dependencies
+++ b/.circle/dependencies
@@ -35,6 +35,8 @@ sudo apt-get -y install libldap2-dev libsasl2-dev
 
 # make `gh` available for github API calls
 ~/ci/.circle/install_gh
+# Hit github's API to keep the PAT active (without failing if it's not)
+(GH_TOKEN=${MACHINE_PASSWORD} gh repo view | head -n2) || true
 
 sudo pip install -U "pip>=9.0,<9.1" setuptools virtualenv
 


### PR DESCRIPTION
PATs expire when unused for a year: https://github.community/t/api-access-token-expiry/14522

So, we need to use it regularly. Adding an API hit to the weekly test run should keep the PAT active indefinitely.

Here we use the dependencies script so that it runs as early as possible each week before most other things might fail and kill the build.

Also, we use `|| true` so that any PR runs can continue passing even if the PAT has expired.
