### PR TITLE
[BUGFIX] Fix support for non-master default branch in packs

### DIFF
--- a/.circle/deployment
+++ b/.circle/deployment
@@ -21,6 +21,10 @@ fi
 # TODO: remove the install_gh call once circleci config is updated in all packs
 type gh &>/dev/null || ~/ci/.circle/install_gh
 
+# GH_TOKEN is used by gh which is used in functions.sh
+export GH_TOKEN=${MACHINE_PASSWORD}
+source ~/ci/tools/functions.sh
+
 # TODO: figure out how to make deploy.py rebuild the index.
 # python ~/packs/.circle/deploy.py pack.yaml "${CIRCLE_PROJECT_REPONAME}"
 
@@ -54,10 +58,11 @@ do
   fi
 done
 
+DEFAULT_BRANCH=$(_gh_default_branch)
 # Afer pushing the version, make sure we check out the latest commit
 # This is important so index reflects latest changes
-git checkout master
-git reset --hard master
+git checkout ${DEFAULT_BRANCH}
+git reset --hard ${DEFAULT_BRANCH}
 
 # Verify there are no unstaged changes
 git status

--- a/.circle/deployment
+++ b/.circle/deployment
@@ -110,10 +110,11 @@ if ! git -C ~/index diff --quiet --exit-code --cached
 then
   echo "Updating the index repo..."
   git -C ~/index commit -m "Update the ${PACK_NAME} pack."
-  if [[ ${SKIP_INDEX:-false} == "true" ]]; then
-    echo "Skipping index update due to SKIP_INDEX=${SKIP_INDEX}"
-    echo "SKIP_INDEX is for packs that are only used in CI;"
-    echo "Normal packs push to the index repo at this point."
+  if [[ ${DO_NOT_ADD_TO_EXCHANGE_INDEX:-false} == "true" ]]; then
+    echo "Normal packs update the Exchange index at this point."
+    echo "This pack will not be added to the Exchange index because of this env var:"
+    echo "DO_NOT_ADD_TO_EXCHANGE_INDEX=${DO_NOT_ADD_TO_EXCHANGE_INDEX}"
+    echo "(This var should only be set per-repo in the CI system's UI.)"
   else
     git -C ~/index push -q origin
     echo "Index updated."

--- a/.circle/deployment
+++ b/.circle/deployment
@@ -27,7 +27,7 @@ source ~/ci/tools/functions.sh
 
 DEFAULT_BRANCH=$(_gh_default_branch)
 # Give a good error message after the first use of github API in this script.
-if $? != 0; then
+if [[ $? != 0 ]]; then
     echo "Error retrieving data with github graphql API."
     echo "The GitHub PAT might need to be regenerated:"
     echo "https://github.com/settings/tokens/new?scopes=public_repo&description=CircleCI%3A%20stackstorm-${PACK_NAME}"

--- a/.circle/deployment
+++ b/.circle/deployment
@@ -110,8 +110,14 @@ if ! git -C ~/index diff --quiet --exit-code --cached
 then
   echo "Updating the index repo..."
   git -C ~/index commit -m "Update the ${PACK_NAME} pack."
-  git -C ~/index push -q origin
-  echo "Index updated."
+  if [[ ${SKIP_INDEX:-false} == "true" ]]; then
+    echo "Skipping index update due to SKIP_INDEX=${SKIP_INDEX}"
+    echo "SKIP_INDEX is for packs that are only used in CI;"
+    echo "Normal packs push to the index repo at this point."
+  else
+    git -C ~/index push -q origin
+    echo "Index updated."
+  fi
 
   # echo "Updating the repo description..."
   # PACK_DESCRIPTION=$(cat ~/index/v1/index.json | jq ".packs.${PACK_NAME}.description")

--- a/.circle/deployment
+++ b/.circle/deployment
@@ -25,6 +25,16 @@ type gh &>/dev/null || ~/ci/.circle/install_gh
 export GH_TOKEN=${MACHINE_PASSWORD}
 source ~/ci/tools/functions.sh
 
+DEFAULT_BRANCH=$(_gh_default_branch)
+# Give a good error message after the first use of github API in this script.
+if $? != 0; then
+    echo "Error retrieving data with github graphql API."
+    echo "The GitHub PAT might need to be regenerated:"
+    echo "https://github.com/settings/tokens/new?scopes=public_repo&description=CircleCI%3A%20stackstorm-${PACK_NAME}"
+else
+    echo "GitHub PAT is active."
+fi
+
 # TODO: figure out how to make deploy.py rebuild the index.
 # python ~/packs/.circle/deploy.py pack.yaml "${CIRCLE_PROJECT_REPONAME}"
 
@@ -58,7 +68,6 @@ do
   fi
 done
 
-DEFAULT_BRANCH=$(_gh_default_branch)
 # Afer pushing the version, make sure we check out the latest commit
 # This is important so index reflects latest changes
 git checkout ${DEFAULT_BRANCH}

--- a/.circle/index.py
+++ b/.circle/index.py
@@ -155,7 +155,7 @@ def get_available_versions():
     if proc.returncode != 0:
         sys.exit(
             "Error retrieving data with github graphql API.\n"
-            "The Github PAT might need to be regenerated:\n"
+            "The GitHub PAT might need to be regenerated:\n"
             "https://github.com/settings/tokens/new?scopes=public_repo"
             "&description=CircleCI%3A%20stackstorm-" + ACTIVE_PACK_NAME
         )

--- a/tools/functions.sh
+++ b/tools/functions.sh
@@ -1,0 +1,13 @@
+#### gh helpers
+
+_gh_default_branch() {
+    # get the default branch for the current repo (might not be master)
+
+    gh api graphql -F owner=':owner' -F name=':repo' -f query='
+      query($name: String!, $owner: String!) {
+        repository(owner: $owner, name: $name) {
+          defaultBranchRef { name }
+        }
+      }
+    ' | jq -r '.data.repository.defaultBranchRef.name'
+}


### PR DESCRIPTION
- Fix support for non-master default pack branches

    If any packs end up using `main` instead of `master` as their default
    branch, then deploying the index will fail without this change.

    Currently only the `test` and `test2` packs use an non-master default
    branch (`aaa`). So, the impact of this change is minimal.

- Provide PAT error message as early as possible

    Resolves #109 by printing a helpful error message much sooner if a PAT has expired.

- Add `DO_NOT_ADD_TO_EXCHANGE_INDEX` for CI packs

    This variable should be set to `true` (a string, not a boolean)
    in CircleCI's web UI for each test pack. This way, such test packs
    can be used to test everything in the CI workflows including
    changes to the `deploy` step's `deployment` script.