### PR TITLE
Fixing exchange bootstrap script with new GitHub and CircleCI api changes

### DIFF
--- a/utils/exchange-bootstrap.sh
+++ b/utils/exchange-bootstrap.sh
@@ -16,11 +16,14 @@
 # * PASSWORD: password for the user (not a token).
 # * CIRCLECI_TOKEN: a CircleCI token for the Exchange organization.
 # * SLACK_WEBHOOK_URL: Full URL to Slack webhook where Github event notifications will be sent.
+# * GITHUB_PACK_PAT: GitHub Personal Access Token for the stackstorm-neptr user
+#                    (url: https://github.com/settings/tokens)
+#                    that has a name "CircleCI: stackstorm-<pack>" and given
+#                    the 'public_repo" scope. This PAT is used by CircleCI to access
+#                    the repo.
 #
 # Optionally, this env variable can be set to send additional Github event notifications
 # * SLACK_WEBHOOK_URL_COMMUNITY
-
-
 set -e
 
 if [[ ! $# -eq 1 ]];

--- a/utils/exchange-bootstrap.sh
+++ b/utils/exchange-bootstrap.sh
@@ -96,12 +96,18 @@ curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X PATCH \
      -d '{"name": "'"${REPO_NAME}"'"}' \
      "https://api.github.com/repos/${EXCHANGE_ORG}/${REPO_ALIAS}"
 
+# No longer needed
 # GitHub: create a read-write key for the repo
-echo "GitHub: Creating a read-write key for the GitHub repo"
-curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X POST \
-     --header "Content-Type: application/json" \
-     -d '{"title": "CircleCI read-write key", "key": "'"$(cat "/tmp/${PACK}_rsa.pub")"'", "read_only": false}' \
-     "https://api.github.com/repos/${EXCHANGE_ORG}/${REPO_NAME}/keys"
+# echo "GitHub: Creating a read-write key for the GitHub repo"
+# curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X POST \
+#      --header "Content-Type: application/json" \
+#      -d '\
+#      { \
+#        "title": "CircleCI read-write key", \
+#        "key": "'"$(cat "/tmp/${PACK}_rsa.pub")"'", \
+#        "read_only": false \
+#      }' \
+#      "https://api.github.com/repos/${EXCHANGE_ORG}/${REPO_NAME}/keys"
 
 # GitHub: create a user-scope token
 echo -n "${GITHUB_PACK_PAT}" > "/tmp/${PACK}_user_token"
@@ -179,11 +185,11 @@ fi
 
 
 # CircleCI: upload the read-write key
-echo "CircleCI: Adding read-write SSH key"
-curl -sS --fail -X POST --header "Content-Type: application/json" \
-     --header "Circle-Token: ${CIRCLECI_TOKEN}" \
-     -d '{"hostname":"github.com","private_key":"'"$(cat "/tmp/${PACK}_rsa")"'"}' \
-     "https://circleci.com/api/v1.1/project/github/${EXCHANGE_ORG}/${REPO_NAME}/ssh-key"
+# echo "CircleCI: Adding read-write SSH key"
+# curl -sS --fail -X POST --header "Content-Type: application/json" \
+#   --header "Circle-Token: ${CIRCLECI_TOKEN}" \
+#   -d '{"hostname":"github.com","private_key":"'"$(cat "/tmp/${PACK}_rsa")"'"}' \
+#   "https://circleci.com/api/v1.1/project/github/${EXCHANGE_ORG}/${REPO_NAME}/ssh-key"
 
 # CircleCI: specify the credentials (the machine login and the new user-scope token)
 echo "CircleCI: Setting credentials (machine login and user-scoped token)"

--- a/utils/exchange-bootstrap.sh
+++ b/utils/exchange-bootstrap.sh
@@ -32,9 +32,9 @@ then
   exit 1;
 fi
 
-PACK="$1"
 EXCHANGE_ORG="${EXCHANGE_ORG:-StackStorm-Exchange}"
 EXCHANGE_PREFIX="${EXCHANGE_PREFIX:-stackstorm}"
+PACK="${1/${EXCHANGE_PREFIX}-/}"  # Ensure that PACK is just the bare pack name
 REPO_ALIAS=${PACK}
 REPO_NAME="${EXCHANGE_PREFIX}-${PACK}"
 REPO_DIR="/tmp/${REPO_NAME}"

--- a/utils/exchange-bootstrap.sh
+++ b/utils/exchange-bootstrap.sh
@@ -16,11 +16,6 @@
 # * PASSWORD: password for the user (not a token).
 # * CIRCLECI_TOKEN: a CircleCI token for the Exchange organization.
 # * SLACK_WEBHOOK_URL: Full URL to Slack webhook where GitHub event notifications will be sent.
-# * GITHUB_PACK_PAT: GitHub Personal Access Token for the stackstorm-neptr user
-#                    (url: https://github.com/settings/tokens)
-#                    that has a name "CircleCI: stackstorm-<pack>" and given
-#                    the 'public_repo" scope. This PAT is used by CircleCI to access
-#                    the repo.
 #
 # Optionally, this env variable can be set to send additional GitHub event notifications
 # * SLACK_WEBHOOK_URL_COMMUNITY
@@ -51,23 +46,6 @@ REPO_NAME="${EXCHANGE_PREFIX}-${PACK}"
 REPO_DIR="/tmp/${REPO_NAME}"
 REPO_URL="https://${USERNAME}:${PASSWORD}@github.com/${EXCHANGE_ORG}/${REPO_NAME}"
 ALIAS_URL="https://${USERNAME}:${PASSWORD}@github.com/${EXCHANGE_ORG}/${REPO_ALIAS}"
-
-# Generating GitHub PAT (personal access tokens) can no longer be done via the API
-# broken: https://developer.github.com/changes/2/#--deprecating-oauth-authorization-api
-if [ -z "${GITHUB_PACK_PAT}" ]; then
-  echo "GitHub disabled the API allowing us to generate Personal Access Tokens for users"
-  echo "Please perform the following steps:"
-  echo "  1) login to GitHub as the 'stackstorm-neptr' account"
-  echo "  2) visit: https://github.com/settings/tokens"
-  echo "  3) click 'Genearte new token'"
-  echo "    3a) Note: CircleCI: ${REPO_NAME}"
-  echo "    3b) Select scopes: public_repo"
-  echo "    3c) Generate token"
-  echo "  4) Copy the new token and export it as the GITHUB_PACK_PAT shell variable"
-  echo "     export GITHUB_PACK_PAT='b4d3xxx'"
-  echo "  5) Re-run this script"
-fi
-
 
 # Check if the repo exists
 

--- a/utils/exchange-bootstrap.sh
+++ b/utils/exchange-bootstrap.sh
@@ -15,14 +15,14 @@
 # * USERNAME: a GitHub user to run the script under (Exchange bot).
 # * PASSWORD: password for the user (not a token).
 # * CIRCLECI_TOKEN: a CircleCI token for the Exchange organization.
-# * SLACK_WEBHOOK_URL: Full URL to Slack webhook where Github event notifications will be sent.
+# * SLACK_WEBHOOK_URL: Full URL to Slack webhook where GitHub event notifications will be sent.
 # * GITHUB_PACK_PAT: GitHub Personal Access Token for the stackstorm-neptr user
 #                    (url: https://github.com/settings/tokens)
 #                    that has a name "CircleCI: stackstorm-<pack>" and given
 #                    the 'public_repo" scope. This PAT is used by CircleCI to access
 #                    the repo.
 #
-# Optionally, this env variable can be set to send additional Github event notifications
+# Optionally, this env variable can be set to send additional GitHub event notifications
 # * SLACK_WEBHOOK_URL_COMMUNITY
 set -e
 
@@ -87,13 +87,13 @@ else
 fi
 
 # GitHub: rename the alias repo to its full name
-echo "Github: Renaming the repo to ${REPO_NAME}."
+echo "GitHub: Renaming the repo to ${REPO_NAME}."
 curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X PATCH --header "Content-Type: application/json" \
      -d '{"name": "'"${REPO_NAME}"'"}' \
      "https://api.github.com/repos/${EXCHANGE_ORG}/${REPO_ALIAS}"
 
 # GitHub: create a read-write key for the repo
-echo "Github: Creating a read-write key for the Github repo"
+echo "GitHub: Creating a read-write key for the GitHub repo"
 curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X POST --header "Content-Type: application/json" \
      -d '{"title": "CircleCI read-write key", "key": "'"$(cat "/tmp/${PACK}_rsa.pub")"'", "read_only": false}' \
      "https://api.github.com/repos/${EXCHANGE_ORG}/${REPO_NAME}/keys"
@@ -120,16 +120,16 @@ git add .gitignore
 git commit -m "Bootstrap a StackStorm Exchange pack repository for pack ${PACK}."
 git push origin master
 
-# Github: Configure webhook to send notifications to our Slack instance on changes
-echo "Github: Configuring Github to send webhook notifications to our Slack"
+# GitHub: Configure webhook to send notifications to our Slack instance on changes
+echo "GitHub: Configuring GitHub to send webhook notifications to our Slack"
 curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X POST --header "Content-Type: application/json" \
      -d '{"name": "web", "active": true, "config": {"url": "'"${SLACK_WEBHOOK_URL}"'", "content_type": "application/json"}, "events": ["commit_comment", "issue_comment", "issues", "pull_request", "pull_request_review", "pull_request_review_comment"]}' \
      "https://api.github.com/repos/${EXCHANGE_ORG}/${REPO_NAME}/hooks"
 
-# Github: If second Slack webhook URL set (e.g. for community), configure that to notify on changes
+# GitHub: If second Slack webhook URL set (e.g. for community), configure that to notify on changes
 if [[ -n $SLACK_WEBHOOK_URL_COMMUNITY ]];
 then
-  echo "Github: Configuring Github to send webhook notifications to our community Slack"
+  echo "GitHub: Configuring GitHub to send webhook notifications to our community Slack"
   curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X POST --header "Content-Type: application/json" \
        -d '{"name": "web", "active": true, "config": {"url": "'"${SLACK_WEBHOOK_URL_COMMUNITY}"'", "content_type": "application/json"}, "events": ["issues", "pull_request"]}' \
        "https://api.github.com/repos/${EXCHANGE_ORG}/${REPO_NAME}/hooks"

--- a/utils/exchange-bootstrap.sh
+++ b/utils/exchange-bootstrap.sh
@@ -41,6 +41,8 @@ REPO_DIR="/tmp/${REPO_NAME}"
 REPO_URL="https://${USERNAME}:${PASSWORD}@github.com/${EXCHANGE_ORG}/${REPO_NAME}"
 ALIAS_URL="https://${USERNAME}:${PASSWORD}@github.com/${EXCHANGE_ORG}/${REPO_ALIAS}"
 
+# Generating GitHub PAT (personal access tokens) can no longer be done via the API
+# broken: https://developer.github.com/changes/2/#--deprecating-oauth-authorization-api
 if [ -z "${GITHUB_PACK_PAT}" ]; then
   echo "GitHub disabled the API allowing us to generate Personal Access Tokens for users"
   echo "Please perform the following steps:"
@@ -96,15 +98,7 @@ curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X POST --header "Content-Type: app
 	-d '{"title": "CircleCI read-write key", "key": "'"$(cat "/tmp/${PACK}_rsa.pub")"'", "read_only": false}' \
 	"https://api.github.com/repos/${EXCHANGE_ORG}/${REPO_NAME}/keys"
 
-GitHub: create a user-scope token
-broken: https://developer.github.com/changes/2/#--deprecating-oauth-authorization-api
-switching to "device flow": https://docs.github.com/en/developers/apps/authorizing-oauth-apps#device-flow
-
-echo "Github: Creating a Github user-scoped token"
-curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X POST --header "Content-Type: application/json" \
-	-d '{"scopes": ["public_repo"], "note": "CircleCI: '"${REPO_NAME}"'"}' \
-	"https://api.github.com/authorizations" | jq ".token" > "/tmp/${PACK}_user_token"
-
+# GitHub: create a user-scope token
 echo -n "${GITHUB_PACK_PAT}" > "/tmp/${PACK}_user_token"
 if [[ ! -s "/tmp/${PACK}_user_token" ]];
 then

--- a/utils/exchange-bootstrap.sh
+++ b/utils/exchange-bootstrap.sh
@@ -75,7 +75,8 @@ git init && git remote add origin "${REPO_URL}"
 echo "Generating random private SSH key"
 ssh-keygen -b 2048 -t rsa -f "/tmp/${PACK}_rsa" -q -N "" -m pem
 
-# GitHub: create a repo or create an alias and move
+# GitHub: create an alias first
+# See https://github.com/StackStorm-Exchange/ci/pull/30
 if git ls-remote "${ALIAS_URL}" > /dev/null 2>&1;
 then
   echo "The alias already exists, skipping the creation."
@@ -88,6 +89,7 @@ else
 fi
 
 # GitHub: rename the alias repo to its full name
+# This will setup a redirect on GitHub: alias -> name
 echo "GitHub: Renaming the repo to ${REPO_NAME}."
 curl -sS --fail -u "${USERNAME}:${PASSWORD}" -X PATCH \
      --header "Content-Type: application/json" \


### PR DESCRIPTION
GitHub and CircleCI broke their APIs.

GitHub doesn't allow us to create PATs anymore via the API, so we need to do that manually. I added a new environment variable `GITHUB_PACK_APT` that is checked and a helpful error message is output.

Also, for whatever reason the CircleCI API for following repos keeps returning 400 Bad Request. I've created a support ticket with them, so we'll see where that goes. It doesn't appear to affect anything as the project shows as "followed" by the stackstorm-neptr user.

On CircleCI i switched over to using their `Circle-Token` header instead of deprecated (no longer working) URL query parameter.