### PR TITLE
Test infra for py2.7 is broken. Drop it.

### DIFF
--- a/.circle/circle.yml.sample
+++ b/.circle/circle.yml.sample
@@ -1,53 +1,6 @@
 version: 2
 
 jobs:
-  build_and_test_python27:
-    docker:
-      - image: circleci/python:2.7
-      - image: rabbitmq:3
-      - image: mongo:3.4
-
-    working_directory: ~/repo
-
-    environment:
-      VIRTUALENV_DIR: "~/virtualenv"
-      # Don't install various StackStorm dependencies which are already
-      # installed by CI again in the various check scripts
-      ST2_INSTALL_DEPS: "0"
-      # 3.3 is the last version to support python27
-      ST2_BRANCH: "v3.3"
-
-    steps:
-      - checkout
-      - restore_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
-      - run:
-          name: Download dependencies
-          command: |
-            git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
-            ~/ci/.circle/dependencies
-      - run:
-          name: Run tests (Python 2.7)
-          command: ~/ci/.circle/test
-      - save_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
-          paths:
-            - ~/.cache/pip
-            - ~/.apt-cache
-      # NOTE: We use virtualenv files from Python 2.7 step in "deploy" job so we
-      # only persist paths from this job
-      - persist_to_workspace:
-          root: /
-          paths:
-            - home/circleci/ci
-            - home/circleci/virtualenv
-            - tmp/st2
-            - home/circleci/repo
-            - home/circleci/.gitconfig
-
-  # NOTE: Until we add "python_version" metadata attribute to pack.yaml and
-  # explicitly call which packs work with Python 3.x, Python 3.x failures are
-  # not considered fatal
   build_and_test_python36:
     docker:
       - image: circleci/python:3.6
@@ -89,10 +42,21 @@ jobs:
           paths:
             - ~/.cache/pip
             - ~/.apt-cache
+      # NOTE: We use virtualenv files from Python 3.6 step in "deploy" job so we
+      # only persist paths from this job
+      - persist_to_workspace:
+          root: /
+          paths:
+            - home/circleci/ci
+            - home/circleci/virtualenv
+            - tmp/st2
+            - home/circleci/repo
+            - home/circleci/.gitconfig
+
 
   deploy:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.6
 
     working_directory: ~/repo
 
@@ -102,7 +66,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
+          key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
       - attach_workspace:
           at: /
       - run:
@@ -123,17 +87,15 @@ workflows:
   # Workflow which runs on each push
   build_test_deploy_on_push:
     jobs:
-      - build_and_test_python27
       - build_and_test_python36
       - deploy:
           requires:
-            - build_and_test_python27
+            - build_and_test_python36
           filters:
             branches:
               only: master
   build_test_weekly:
     jobs:
-      - build_and_test_python27
       - build_and_test_python36
     # Workflow which runs nightly - note we don't perform deploy job on nightly
     # build


### PR DESCRIPTION
We will no longer test packs with python2.7, as it is broken and the fix
(re-adding 2.7) is too invasive across all of our infrastructure.

We continue supporting 2.7 but only on an as-reported basis.
If someone submits a PR for 2.7 and it doesn't break with python 3, great.
If a pack is upgraded so that it can only be used with python 3,
then people can downgrade to an earlier version that supported python 2.