### PR TITLE
Fix deployment if git checkout becomes unclean

### DIFF
--- a/.circle/deployment
+++ b/.circle/deployment
@@ -70,7 +70,7 @@ done
 
 # Afer pushing the version, make sure we check out the latest commit
 # This is important so index reflects latest changes
-git checkout ${DEFAULT_BRANCH}
+git checkout --force ${DEFAULT_BRANCH}
 git reset --hard ${DEFAULT_BRANCH}
 
 # Verify there are no unstaged changes


### PR DESCRIPTION
The basic logic of the `deployment` script is:

1. get the list of commit hashes that modified `pack.yaml`
2. loop through each of those commit hashes
   - check out `pack.yaml` from that commit
   - if the version tag listed in `pack.yaml` is missing, tag the commit and push the tag
3. checkout `master` branch again (or whichever branch is default)
4. prepare/push the exchange index update

The checkout can become dirty in step 2 (see below).
This PR fixes step 3, by adding `--force` to the `git checkout` so it doesn't die if the checkout is dirty.

The checkout might be unclean if a script fails to parse old pack.yaml files.

This happens, for example, with the test pack. The test pack moved from version `0.3` to version `0.3.0` when semantic versioning was introduced/enforced. But `0.3` is not a valid semantic version, so one of the scripts ends up collapsing with the old version number.

The script actually handles this case correctly and just continue past the bad tag, but the git checkout is no longer clean so checking out `master` fails, which stops the script earlier than we intended.