### PR TITLE
gha: cleanups

### DIFF
--- a/.github/actions/checkout/action.yaml
+++ b/.github/actions/checkout/action.yaml
@@ -53,7 +53,7 @@ runs:
         repository: StackStorm/st2
         ref: ${{ inputs.st2-branch }}
         path: st2
-        fetch-depth: 1
+        fetch-depth: ${{ inputs.st2-branch == 'master' && 1 || 0 }}
 
     - name: Checkout lint-configs repo
       uses: actions/checkout@v2
@@ -61,4 +61,4 @@ runs:
         repository: StackStorm/lint-configs
         ref: ${{ inputs.lint-configs-branch }}
         path: lint-configs
-        fetch-depth: 1
+        fetch-depth: ${{ inputs.lint-configs-branch == 'master' && 1 || 0 }}

--- a/.github/actions/py-dependencies/action.yaml
+++ b/.github/actions/py-dependencies/action.yaml
@@ -84,7 +84,7 @@ runs:
           # grab the pinned versions from the st2 checkout
           grep -E "${REQUIREMENTS// /[ =><]|}[ =><]" ${ST2_REPO_PATH}/test-requirements.txt > ${GITHUB_WORKSPACE}/${req_file}
           # grab any local pinned requirements
-          grep -e '=' "${REQUIREMENTS_DIR}/${req_file}" >> ${GITHUB_WORKSPACE}/${req_file}
+          grep -e '=' "${REQUIREMENTS_DIR}/${req_file}" >> ${GITHUB_WORKSPACE}/${req_file} || true
           echo ${GITHUB_WORKSPACE}/${req_file}:
           cat ${GITHUB_WORKSPACE}/${req_file}
           echo

--- a/.github/actions/py-dependencies/action.yaml
+++ b/.github/actions/py-dependencies/action.yaml
@@ -89,7 +89,7 @@ runs:
           cat ${GITHUB_WORKSPACE}/${req_file}
           echo
           # install
-          ${VIRTUALENV_DIR}/bin/pip install -q -r ${GITHUB_WORKSPACE}/${req_file}
+          ${VIRTUALENV_DIR}/bin/pip install -r ${GITHUB_WORKSPACE}/${req_file}
           echo "::endgroup::"
         done
 
@@ -99,7 +99,7 @@ runs:
       working-directory: st2
       run: |
         echo "::group::Install StackStorm Requirements"
-        ${VIRTUALENV_DIR}/bin/pip install -q -r requirements.txt
+        ${VIRTUALENV_DIR}/bin/pip install -r requirements.txt
         echo "::endgroup::"
 
     - name: Install Runners

--- a/.github/actions/py-dependencies/action.yaml
+++ b/.github/actions/py-dependencies/action.yaml
@@ -84,7 +84,7 @@ runs:
           # grab the pinned versions from the st2 checkout
           grep -E "${REQUIREMENTS// /[ =><]|}[ =><]" ${ST2_REPO_PATH}/test-requirements.txt > ${GITHUB_WORKSPACE}/${req_file}
           # grab any local pinned requirements
-          grep -e '=' "${REQUIREMENTS_DIR}/requirements-dev.txt" >> ${GITHUB_WORKSPACE}/${req_file}
+          grep -e '=' "${REQUIREMENTS_DIR}/${req_file}" >> ${GITHUB_WORKSPACE}/${req_file}
           echo ${GITHUB_WORKSPACE}/${req_file}:
           cat ${GITHUB_WORKSPACE}/${req_file}
           echo

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -49,6 +49,8 @@ runs:
         echo "BASE_BRANCH=origin/${DEFAULT_BRANCH}" >> ${GITHUB_ENV}
         if [[ "${DEFAULT_BRANCH}" == "${GITHUB_REF_NAME}" ]]; then
           echo "FORCE_CHECK_ALL_FILES=true" >> ${GITHUB_ENV}
+        else
+          echo "FORCE_CHECK_ALL_FILES=${FORCE_CHECK_ALL_FILES:-true}" >> ${GITHUB_ENV}
         fi
         if [[ "true" == "${{ inputs.enable-common-libs }}" ]]; then
           echo "Common libs PATH selected"

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -15,6 +15,12 @@ inputs:
       see: https://docs.stackstorm.com/reference/sharing_code_sensors_actions.html
     default: false
     required: false
+  force-check-all-files:
+    description: |
+      Pushes to the default branch always check all files.
+      If needed, a pack can limit checks for PRs by setting this to false.
+    default: true
+    required: false
 
 outputs:
   pack-name:
@@ -50,7 +56,7 @@ runs:
         if [[ "${DEFAULT_BRANCH}" == "${GITHUB_REF_NAME}" ]]; then
           echo "FORCE_CHECK_ALL_FILES=true" >> ${GITHUB_ENV}
         else
-          echo "FORCE_CHECK_ALL_FILES=${FORCE_CHECK_ALL_FILES:-true}" >> ${GITHUB_ENV}
+          echo "FORCE_CHECK_ALL_FILES=${{ inputs.force-check-all-files }}" >> ${GITHUB_ENV}
         fi
         if [[ "true" == "${{ inputs.enable-common-libs }}" ]]; then
           echo "Common libs PATH selected"

--- a/.github/workflows/pack-build_and_test.yaml
+++ b/.github/workflows/pack-build_and_test.yaml
@@ -26,6 +26,10 @@ on:
         required: false
         type: string
         default: master
+      force-check-all-files:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   build_and_test:
@@ -60,6 +64,7 @@ jobs:
         uses: StackStorm-Exchange/ci/.github/actions/test@master
         with:
           enable-common-libs: ${{ inputs.enable-common-libs }}
+          force-check-all-files: ${{ inputs.force-check-all-files }}
 
     services:
       mongo:


### PR DESCRIPTION
- set FORCE_CHECK_ALL_FILES=true by default (see #88)
- do not obscure the pip output with `pip -q`. Instead we can use gha output groups to jump past it.
- if a different branch of st2 or lint-configs is selected, then we need more than just one commit (`fetch-depth: 1`). So, if the branch is set to anything other than the default branch (`master`) then set `fetch-depth: 0` so that all history gets included.

Tested at https://github.com/StackStorm-Exchange/stackstorm-test/runs/4644706724