### PR TITLE
pin GHA runners to ubuntu-20.04

### DIFF
--- a/.github/workflows/index-update.yaml
+++ b/.github/workflows/index-update.yaml
@@ -46,7 +46,7 @@ on:
 
 jobs:
   regenerate_index:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # When parent workflow is named "Update Index" this shows up as:
     #   "Update Index / Regenerate"
     name: Regenerate

--- a/.github/workflows/pack-bootstrap_repo.yaml
+++ b/.github/workflows/pack-bootstrap_repo.yaml
@@ -61,7 +61,7 @@ on:
 
 jobs:
   bootstrap_pack_repo:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: 'Bootstrap Repo'
     env:
       # GH_TOKEN used by `gh` command

--- a/.github/workflows/pack-build_and_test.yaml
+++ b/.github/workflows/pack-build_and_test.yaml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # When parent workflow is named "Build and Test" this shows up as:
     #   "Build and Test / Python 3.6"
     name: 'Python ${{ matrix.python-version-short }}'

--- a/.github/workflows/pack-repo_meta.yaml
+++ b/.github/workflows/pack-repo_meta.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   repo_meta:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: 'Repo Metadata'
 
     outputs:

--- a/.github/workflows/pack-tag_release.yaml
+++ b/.github/workflows/pack-tag_release.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   tag_release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: 'Tag Release'
 
     outputs:


### PR DESCRIPTION
This mirrors StackStorm/st2#5832 and fixes the index builds that have been failing.

See: https://github.com/StackStorm-Exchange/index/actions