### PR TITLE
CI: Add Python 3.8 to testing

### DIFF
--- a/.github/workflows/pack-build_and_test.yaml
+++ b/.github/workflows/pack-build_and_test.yaml
@@ -35,7 +35,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-20.04
     # When parent workflow is named "Build and Test" this shows up as:
-    #   "Build and Test / Python 3.6"
+    #   "Build and Test / Python 3.X"
     name: 'Python ${{ matrix.python-version-short }}'
     strategy:
       fail-fast: false

--- a/.github/workflows/pack-build_and_test.yaml
+++ b/.github/workflows/pack-build_and_test.yaml
@@ -38,17 +38,21 @@ jobs:
     #   "Build and Test / Python 3.6"
     name: 'Python ${{ matrix.python-version-short }}'
     strategy:
+      fail-fast: false
+      max-parallel: 2
       matrix:
         include:
           - python-version-short: "3.6"
             python-version: 3.6.13
+          - python-version-short: "3.8"
+            python-version: 3.8.10
     steps:
       - name: Checkout Pack Repo and CI Repos
         uses: StackStorm-Exchange/ci/.github/actions/checkout@master
         with:
           st2-branch: ${{ inputs.st2-branch }}
           lint-configs-branch: ${{ inputs.lint-configs-branch }}
-        
+
       - name: Install APT Dependencies
         uses: StackStorm-Exchange/ci/.github/actions/apt-dependencies@master
         with:


### PR DESCRIPTION
Here's an [example](https://github.com/mamercad/stackstorm-jira/actions/runs/3725233753) running on my forks and branches; relates to [this](https://github.com/StackStorm-Exchange/stackstorm-jira/pull/49).