### PR TITLE
CI: Pack metadata validation

### DIFF
--- a/.github/actions/pack-meta/action.yaml
+++ b/.github/actions/pack-meta/action.yaml
@@ -1,0 +1,72 @@
+---
+name: Run pack metadata tests
+description: |
+  Run StackStorm-Exchange pack metadata tests.
+  Ensure CHANGES.md changed.
+  Ensure pack.yaml changed.
+  Ensure proposed Pack version > current version.
+author: StackStorm
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout index repo
+      uses: actions/checkout@v3
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v35
+
+    - name: Ensure CHANGES.md or CHANGELOG.md and pack.yaml updated
+      shell: bash
+      run: |
+        echo "::group::Ensure CHANGES.md or CHANGELOG.md and pack.yaml updated"
+        changed_files=(${{ steps.changed-files.outputs.all_changed_files }})
+
+        if [[ " ${changed_files[*]} " =~ " CHANGES.md " ]]; then
+          echo "::notice::CHANGES.md was updated"
+        elif [[ " ${changed_files[*]} " =~ " CHANGELOG.md " ]]; then
+          echo "::notice::CHANGELOG.md was updated"
+        else
+          echo "::error::Please update either CHANGES.md or CHANGELOG.md"
+          exit 1
+        fi
+
+        if [[ " ${changed_files[*]} " =~ " pack.yaml " ]]; then
+          echo "::notice::pack.yaml was updated"
+        else
+          echo "::error::Please update pack.yaml"
+          exit 1
+        fi
+        echo "::endgroup::"
+
+    - name: Ensure semver increased
+      shell: bash
+      run: |
+        echo "::group::Install yq and semver"
+        pip3 install --user yq semver
+        echo "::endgroup::"
+
+        echo "::group::Get version from pack.yaml (remote and local)"
+        CURRENT_VERSION="$(git show origin/${GITHUB_BASE_REF}:pack.yaml | yq -r .version)"
+        echo "CURRENT_VERSION=${CURRENT_VERSION}" | tee -a ${GITHUB_ENV}
+        PROPOSE_VERSION="$(yq -r .version < pack.yaml)"
+        echo "PROPOSE_VERSION=${PROPOSE_VERSION}" | tee -a ${GITHUB_ENV}
+        echo "::endgroup::"
+
+        echo "::group::Ensure semver increased"
+        # Ensure PACK_VERSION > CURRENT_VERSION
+        semver_compare="$(python3 -c 'import semver, sys; print(semver.compare(sys.argv[1], sys.argv[2]))' $PROPOSE_VERSION $CURRENT_VERSION)"
+        if [[ $semver_compare -eq -1 ]]; then
+          echo "::error::Please increase pack version: proposed pack version ${PROPOSE_VERSION} < current pack version ${CURRENT_VERSION})"
+          exit 1
+        elif [[ $semver_compare -eq 0 ]]; then
+          echo "::error::Please increase pack version: proposed pack version ${PROPOSE_VERSION} = current pack version ${CURRENT_VERSION})"
+          exit 1
+        elif [[ $semver_compare -eq 1 ]]; then
+          echo "::notice::Proposed pack version ${PROPOSE_VERSION} > current pack version ${CURRENT_VERSION})"
+        else
+          echo "::error::Unexpected version comparison result ${semver_compare}!"
+          exit 1
+        fi
+        echo "::endgroup::"

--- a/.github/workflows/pack-build_and_test.yaml
+++ b/.github/workflows/pack-build_and_test.yaml
@@ -49,22 +49,22 @@ jobs:
           st2-branch: ${{ inputs.st2-branch }}
           lint-configs-branch: ${{ inputs.lint-configs-branch }}
 
-      # - name: Install APT Dependencies
-      #   uses: StackStorm-Exchange/ci/.github/actions/apt-dependencies@master
-      #   with:
-      #     cache-version: ${{ inputs.apt-cache-version }}
+      - name: Install APT Dependencies
+        uses: StackStorm-Exchange/ci/.github/actions/apt-dependencies@master
+        with:
+          cache-version: ${{ inputs.apt-cache-version }}
 
-      # - name: Install Python Dependencies
-      #   uses: StackStorm-Exchange/ci/.github/actions/py-dependencies@master
-      #   with:
-      #     cache-version: ${{ inputs.py-cache-version }}
-      #     python-version: ${{ matrix.python-version }}
+      - name: Install Python Dependencies
+        uses: StackStorm-Exchange/ci/.github/actions/py-dependencies@master
+        with:
+          cache-version: ${{ inputs.py-cache-version }}
+          python-version: ${{ matrix.python-version }}
 
-      # - name: Run pack tests
-      #   uses: StackStorm-Exchange/ci/.github/actions/test@master
-      #   with:
-      #     enable-common-libs: ${{ inputs.enable-common-libs }}
-      #     force-check-all-files: ${{ inputs.force-check-all-files }}
+      - name: Run pack tests
+        uses: StackStorm-Exchange/ci/.github/actions/test@master
+        with:
+          enable-common-libs: ${{ inputs.enable-common-libs }}
+          force-check-all-files: ${{ inputs.force-check-all-files }}
 
       - name: Ensure CHANGES.md and pack.yaml changed (and Pack version increased)
         uses: mamercad/stackstorm-exchange-ci/.github/actions/pack-meta@changelog-and-pack-checking

--- a/.github/workflows/pack-build_and_test.yaml
+++ b/.github/workflows/pack-build_and_test.yaml
@@ -67,7 +67,7 @@ jobs:
           force-check-all-files: ${{ inputs.force-check-all-files }}
 
       - name: Ensure CHANGES.md and pack.yaml changed (and Pack version increased)
-        uses: mamercad/stackstorm-exchange-ci/.github/actions/pack-meta@changelog-and-pack-checking
+        uses: StackStorm-Exchange/ci/.github/actions/pack-meta@master
 
     services:
       mongo:

--- a/.github/workflows/pack-build_and_test.yaml
+++ b/.github/workflows/pack-build_and_test.yaml
@@ -67,6 +67,7 @@ jobs:
           force-check-all-files: ${{ inputs.force-check-all-files }}
 
       - name: Ensure CHANGES.md and pack.yaml changed (and Pack version increased)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: StackStorm-Exchange/ci/.github/actions/pack-meta@master
 
     services:

--- a/.github/workflows/pack-build_and_test.yaml
+++ b/.github/workflows/pack-build_and_test.yaml
@@ -48,23 +48,26 @@ jobs:
         with:
           st2-branch: ${{ inputs.st2-branch }}
           lint-configs-branch: ${{ inputs.lint-configs-branch }}
-        
-      - name: Install APT Dependencies
-        uses: StackStorm-Exchange/ci/.github/actions/apt-dependencies@master
-        with:
-          cache-version: ${{ inputs.apt-cache-version }}
 
-      - name: Install Python Dependencies
-        uses: StackStorm-Exchange/ci/.github/actions/py-dependencies@master
-        with:
-          cache-version: ${{ inputs.py-cache-version }}
-          python-version: ${{ matrix.python-version }}
+      # - name: Install APT Dependencies
+      #   uses: StackStorm-Exchange/ci/.github/actions/apt-dependencies@master
+      #   with:
+      #     cache-version: ${{ inputs.apt-cache-version }}
 
-      - name: Run pack tests
-        uses: StackStorm-Exchange/ci/.github/actions/test@master
-        with:
-          enable-common-libs: ${{ inputs.enable-common-libs }}
-          force-check-all-files: ${{ inputs.force-check-all-files }}
+      # - name: Install Python Dependencies
+      #   uses: StackStorm-Exchange/ci/.github/actions/py-dependencies@master
+      #   with:
+      #     cache-version: ${{ inputs.py-cache-version }}
+      #     python-version: ${{ matrix.python-version }}
+
+      # - name: Run pack tests
+      #   uses: StackStorm-Exchange/ci/.github/actions/test@master
+      #   with:
+      #     enable-common-libs: ${{ inputs.enable-common-libs }}
+      #     force-check-all-files: ${{ inputs.force-check-all-files }}
+
+      - name: Ensure CHANGES.md and pack.yaml changed (and Pack version increased)
+        uses: mamercad/stackstorm-exchange-ci/.github/actions/pack-meta@changelog-and-pack-checking
 
     services:
       mongo:


### PR DESCRIPTION
Ensure `CHANGES.md` or `CHANGELOG.md` and `pack.yaml` has been updated; in addition, ensure that the proposed pack version in `pack.yaml` is higher.

Here are some example runs in my forks and branches:

- [`CHANGES.md` or `CHANGELOG.md` not updated](https://github.com/mamercad/stackstorm-test-pack/actions/runs/3742313106)
- [`pack.yaml` not updated](https://github.com/mamercad/stackstorm-test-pack/actions/runs/3742331784)
- [Proposed pack version equal](https://github.com/mamercad/stackstorm-test-pack/actions/runs/3742342955)
- [Proposed pack version lower](https://github.com/mamercad/stackstorm-test-pack/actions/runs/3742359747)
- [All checks passing](https://github.com/mamercad/stackstorm-test-pack/actions/runs/3742361691)

Fixes #134.