### PR TITLE
replace deprecated `::set-output` w/ `${GITHUB_OUTPUT}`

### DIFF
--- a/.github/actions/extract-pack-meta/action.yaml
+++ b/.github/actions/extract-pack-meta/action.yaml
@@ -100,9 +100,9 @@ runs:
       id: collected
       shell: bash
       run: |
-        echo "::set-output name=pack_ref::${PACK_REF}"
-        echo "::set-output name=pack_name::${PACK_NAME}"
-        echo "::set-output name=pack_description::${PACK_DESCRIPTION}"
-        echo "::set-output name=pack_path::${PACK_PATH}"
-        echo "::set-output name=in_submodule::${IN_SUBMODULE}"
-        echo "::set-output name=in_subdir::${IN_SUBDIR}"
+        echo "pack_ref=${PACK_REF}" >> ${GITHUB_OUTPUT}
+        echo "pack_name=${PACK_NAME}" >> ${GITHUB_OUTPUT}
+        echo "pack_description=${PACK_DESCRIPTION}" >> ${GITHUB_OUTPUT}
+        echo "pack_path=${PACK_PATH}" >> ${GITHUB_OUTPUT}
+        echo "in_submodule=${IN_SUBMODULE}" >> ${GITHUB_OUTPUT}
+        echo "in_subdir=${IN_SUBDIR}" >> ${GITHUB_OUTPUT}

--- a/.github/actions/py-dependencies/action.yaml
+++ b/.github/actions/py-dependencies/action.yaml
@@ -68,7 +68,7 @@ runs:
       run: |
         echo "::group::Create ~/virtualenv"
         PIP_VERSION=$(grep '^PIP_VERSION' Makefile | awk '{print $3}')
-        echo "::set-output name=pip-version::${PIP_VERSION}"
+        echo "pip-version=${PIP_VERSION}" >> ${GITHUB_OUTPUT}
         [[ -x "${VIRTUALENV_DIR}/bin/python" ]] || virtualenv --pip "${PIP_VERSION}" ~/virtualenv
         ${VIRTUALENV_DIR}/bin/pip install -q -U "pip==${PIP_VERSION}" setuptools
         echo "::endgroup::"

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -41,7 +41,7 @@ runs:
           echo "Unable to retrieve pack name."
           exit 1
         fi
-        echo "::set-output name=pack-name::${PACK_NAME}"
+        echo "pack-name=${PACK_NAME}" >> ${GITHUB_OUTPUT}
 
     - name: Add CI vars to env context
       shell: bash

--- a/.github/workflows/pack-bootstrap_repo.yaml
+++ b/.github/workflows/pack-bootstrap_repo.yaml
@@ -79,8 +79,8 @@ jobs:
         id: collected
         shell: bash
         run: |
-          echo "::set-output name=pack_repo::${{ format('{0}/{1}-{2}', inputs.pack_org, inputs.pack_repo_prefix, inputs.pack_name) }}"
-          echo "::set-output name=homepage::${{ inputs.homepage }}"
+          echo "pack_repo=${{ format('{0}/{1}-{2}', inputs.pack_org, inputs.pack_repo_prefix, inputs.pack_name) }}" >> ${GITHUB_OUTPUT}
+          echo "homepage=${{ inputs.homepage }}" >> ${GITHUB_OUTPUT}
 
       - name: Check if pack repo needs to be created
         id: do-create-repo


### PR DESCRIPTION
Github deprecated using the `::set-output` command in workflows/actions. Instead, we are supposed to use a environment file at `${GITHUB_OUTPUT}`.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/