### PR TITLE
Build/Test: Bump to mongo 7.0 and remove py3.11

### DIFF
--- a/.github/workflows/pack-build_and_test.yaml
+++ b/.github/workflows/pack-build_and_test.yaml
@@ -14,7 +14,7 @@ on:
       python-version:
         required: false
         type: string
-        default: '["3.8", "3.9", "3.10", "3.11"]'
+        default: '["3.8", "3.9", "3.10"]'
       enable-common-libs:
         description: |
           When true, use an st2.conf that sets packs.enable_common_libs=true
@@ -39,7 +39,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-20.04
     # When parent workflow is named "Build and Test" this shows up as:
-    #   "Build and Test / Python 3.8,3.9,3.10,3.11"
+    #   "Build and Test / Python 3.8,3.9,3.10"
     name: 'Python ${{ matrix.python-version }}'
     strategy:
       matrix:
@@ -74,7 +74,7 @@ jobs:
 
     services:
       mongo:
-        image: mongo:4.4
+        image: mongo:7.0
         ports:
           - 27017:27017
       rabbitmq:


### PR DESCRIPTION
Python 3.11 doesn't pass on some packs and isn't officially supported as yet, so it's removed for now.