### PR TITLE
Install pytest helper packages for pack testing

### DIFF
--- a/.github/actions/py-dependencies/action.yaml
+++ b/.github/actions/py-dependencies/action.yaml
@@ -78,13 +78,19 @@ runs:
     - name: Install CI Requirements
       if: inputs.mode == 'pack'
       shell: bash
+      # This installs any non-pinned version package found in the requirements-dev.txt and requirements-pack-tests.txt 
+      # that has a matching entry in st2/test-requirements.txt
       run: |
         for req_file in requirements-dev.txt requirements-pack-tests.txt; do
           echo "::group::Install CI Requirements from ${req_file}"
           # grab any local unpinned requirements
           REQUIREMENTS=$(grep -v -e '^#' -e '=' "${REQUIREMENTS_DIR}/${req_file}" | xargs echo -n)
+          # escape any requirements using brackets to not fail regex
+          # package-name[dependency] => package-name\[dependency\]
+          ESCAPED_REQUIREMENTS=$(echo $REQUIREMENTS | sed 's|\[\(.*\)\]|\\[\1\\]|g')
           # grab the pinned versions from the st2 checkout
-          grep -E "${REQUIREMENTS// /[ =><]|}[ =><]" ${ST2_REPO_PATH}/test-requirements.txt > ${GITHUB_WORKSPACE}/${req_file}
+          # using shell parameter expansion replace spaces with [ =><]| to work with grep regex
+          grep -E "${ESCAPED_REQUIREMENTS// /[ =><]|}[ =><]" ${ST2_REPO_PATH}/test-requirements.txt > ${GITHUB_WORKSPACE}/${req_file}
           # grab any local pinned requirements
           grep -e '=' "${REQUIREMENTS_DIR}/${req_file}" >> ${GITHUB_WORKSPACE}/${req_file} || true
           echo ${GITHUB_WORKSPACE}/${req_file}:

--- a/.github/actions/py-dependencies/action.yaml
+++ b/.github/actions/py-dependencies/action.yaml
@@ -78,8 +78,8 @@ runs:
     - name: Install CI Requirements
       if: inputs.mode == 'pack'
       shell: bash
-      # This installs any non-pinned version package found in the requirements-dev.txt and requirements-pack-tests.txt 
-      # that has a matching entry in st2/test-requirements.txt
+      # This installs any packages found in the requirements-dev.txt and requirements-pack-tests.txt 
+      # with a pinned version or that has a matching entry in st2/test-requirements.txt
       run: |
         for req_file in requirements-dev.txt requirements-pack-tests.txt; do
           echo "::group::Install CI Requirements from ${req_file}"

--- a/.github/actions/py-dependencies/requirements-pack-tests.txt
+++ b/.github/actions/py-dependencies/requirements-pack-tests.txt
@@ -1,3 +1,7 @@
 mock
 unittest2
 nose
+pytest-benchmark[histogram]
+pytest-icdiff
+pytest-cov
+pytest-xdist

--- a/.github/actions/py-dependencies/requirements-pack-tests.txt
+++ b/.github/actions/py-dependencies/requirements-pack-tests.txt
@@ -1,6 +1,4 @@
 mock
-unittest2
-nose
 pytest-benchmark[histogram]
 pytest-icdiff
 pytest-cov


### PR DESCRIPTION
The `Install CI Requirements` step for pack testing checks all packages in `requirements-dev.txt requirements-pack-tests.txt` found in this repo for a corresponding package in the `st2/test-requirements.txt` if there is a match, then the package will be installed. 

Due to the version of pytest being installed in `st2/requirements.txt` (7.0.1) additional pytest helper packages need to be installed to enable the `--cov` and other flags. These were being skipped because they were not called out in the above `requirements-dev.txt requirements-pack-tests.txt` files.

After adding the packages, an issue with the regex was not accounting for packages that were installing sub dependencies using `package-name[dependency]`, these packages would be skipped as the `[dependency]` would be read as a regex instead as literal.

**My Testing**

Running for `requirements-dev.txt`
```
> cat requirements-dev.txt
pyyaml
pep8
flake8==3.7.7
astroid
pylint
isort
```
Output:
```
::group::Install CI Requirements from requirements-dev.txt
./github//requirements-dev.txt:
pep8==1.7.1
astroid==3.1.0
pylint==3.1.1
isort>=4.2.5
pyyaml==6.0.2
flake8==3.7.7
```

Running for `requirements-pack-tests.txt`
```
> cat requirements-pack-tests.txt
mock
unittest2
nose
pytest-benchmark[histogram]
pytest-icdiff
pytest-cov
pytest-xdist
```
Output
```
::group::Install CI Requirements from requirements-pack-tests.txt
mock==5.1.0
pytest-benchmark[histogram]==3.4.1
pytest-icdiff==0.9
pytest-cov==3.0.0
pytest-xdist==2.5.0
```

*Note* that it is expected nose and unittest2 to not be included in the output, they do not have a matching package declaration in st2/test-requirements.txt, so they are skipped. To reduce confusion I've removed them.
