### PR TITLE
Update to ubuntu-22.04

### DIFF
--- a/.github/workflows/enable-pack-build-and-test.yaml
+++ b/.github/workflows/enable-pack-build-and-test.yaml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   enable_pack_build_and_test_workflow:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Enable Pack Build and Test workflow
 
     steps:

--- a/.github/workflows/index-update.yaml
+++ b/.github/workflows/index-update.yaml
@@ -46,7 +46,7 @@ on:
 
 jobs:
   regenerate_index:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # When parent workflow is named "Update Index" this shows up as:
     #   "Update Index / Regenerate"
     name: Regenerate

--- a/.github/workflows/pack-bootstrap_repo.yaml
+++ b/.github/workflows/pack-bootstrap_repo.yaml
@@ -59,7 +59,7 @@ on:
 
 jobs:
   bootstrap_pack_repo:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: 'Bootstrap Repo'
     env:
       # GH_TOKEN used by `gh` command

--- a/.github/workflows/pack-build_and_test.yaml
+++ b/.github/workflows/pack-build_and_test.yaml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # When parent workflow is named "Build and Test" this shows up as:
     #   "Build and Test / Python 3.8,3.9,3.10"
     name: 'Python ${{ matrix.python-version }}'

--- a/.github/workflows/pack-repo_meta.yaml
+++ b/.github/workflows/pack-repo_meta.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   repo_meta:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: 'Repo Metadata'
 
     outputs:

--- a/.github/workflows/pack-tag_release.yaml
+++ b/.github/workflows/pack-tag_release.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   tag_release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: 'Tag Release'
 
     outputs:


### PR DESCRIPTION
```
We will soon start the deprecation process for Ubuntu 20.04. While the image is being deprecated, you may experience longer queue times during peak usage hours. Deprecation will begin on 2025-02-01 and the image will be fully unsupported by 2025-04-01.
```